### PR TITLE
Correctly set Xamarin Mono SDKs

### DIFF
--- a/Scripts/DevOps/Publish.yml
+++ b/Scripts/DevOps/Publish.yml
@@ -58,30 +58,31 @@ stages:
           - bash: |
               ls -l /Library/Frameworks/Mono.framework/Versions/
               ls -l /Library/Frameworks/Xamarin.Mac.framework/Versions/
-          # - template: Templates/PublishMacOSSteps.yml
-          #   parameters:
-          #     phase: Alpha
 
-          # - task: Bash@3
-          #   displayName: Create Disk Image
-          #   inputs:
-          #     targetType: inline
-          #     script: |
-          #       echo "Input: Target/$(BuildPlatform)/$(BuildConfiguration)/Unjammit.macOS/Unjammit.app"
-          #       echo "Renaming"
-          #       mv Target/$(BuildPlatform)/$(BuildConfiguration)/Unjammit.macOS/Unjammit.app \
-          #         "Target/$(BuildPlatform)/$(BuildConfiguration)/Unjammit.macOS/Unjammit Alpha.app"
-          #       echo "Output: $(Build.ArtifactStagingDirectory)/Unjammit.dmg"
-          #       hdiutil create -format UDZO \
-          #         -srcfolder "$(Build.SourcesDirectory)/Target/$(BuildPlatform)/$(BuildConfiguration)/Unjammit.macOS/Unjammit Alpha.app" \
-          #         $(Build.ArtifactStagingDirectory)/Unjammit.dmg
+          - template: Templates/PublishMacOSSteps.yml
+            parameters:
+              phase: Alpha
 
-          # - task: PublishBuildArtifacts@1
-          #   displayName: 'Publish artifact: macOS-Alpha'
-          #   inputs:
-          #     PathtoPublish: $(Build.ArtifactStagingDirectory)
-          #     ArtifactName: macOS-Alpha
-          #     publishLocation: Container
+          - task: Bash@3
+            displayName: Create Disk Image
+            inputs:
+              targetType: inline
+              script: |
+                echo "Input: Target/$(BuildPlatform)/$(BuildConfiguration)/Unjammit.macOS/Unjammit.app"
+                echo "Renaming"
+                mv Target/$(BuildPlatform)/$(BuildConfiguration)/Unjammit.macOS/Unjammit.app \
+                  "Target/$(BuildPlatform)/$(BuildConfiguration)/Unjammit.macOS/Unjammit Alpha.app"
+                echo "Output: $(Build.ArtifactStagingDirectory)/Unjammit.dmg"
+                hdiutil create -format UDZO \
+                  -srcfolder "$(Build.SourcesDirectory)/Target/$(BuildPlatform)/$(BuildConfiguration)/Unjammit.macOS/Unjammit Alpha.app" \
+                  $(Build.ArtifactStagingDirectory)/Unjammit.dmg
+
+          - task: PublishBuildArtifacts@1
+            displayName: 'Publish artifact: macOS-Alpha'
+            inputs:
+              PathtoPublish: $(Build.ArtifactStagingDirectory)
+              ArtifactName: macOS-Alpha
+              publishLocation: Container
 
       # - job:
       #   displayName: iOS

--- a/Scripts/DevOps/Publish.yml
+++ b/Scripts/DevOps/Publish.yml
@@ -55,30 +55,33 @@ stages:
           vmImage: $(Job.VmImage)
 
         steps:
-          - template: Templates/PublishMacOSSteps.yml
-            parameters:
-              phase: Alpha
+          - bash: |
+              ls -l /Library/Frameworks/Mono.framework/Versions/
+              ls -l /Library/Frameworks/Xamarin.Mac.framework/Versions/
+          # - template: Templates/PublishMacOSSteps.yml
+          #   parameters:
+          #     phase: Alpha
 
-          - task: Bash@3
-            displayName: Create Disk Image
-            inputs:
-              targetType: inline
-              script: |
-                echo "Input: Target/$(BuildPlatform)/$(BuildConfiguration)/Unjammit.macOS/Unjammit.app"
-                echo "Renaming"
-                mv Target/$(BuildPlatform)/$(BuildConfiguration)/Unjammit.macOS/Unjammit.app \
-                  "Target/$(BuildPlatform)/$(BuildConfiguration)/Unjammit.macOS/Unjammit Alpha.app"
-                echo "Output: $(Build.ArtifactStagingDirectory)/Unjammit.dmg"
-                hdiutil create -format UDZO \
-                  -srcfolder "$(Build.SourcesDirectory)/Target/$(BuildPlatform)/$(BuildConfiguration)/Unjammit.macOS/Unjammit Alpha.app" \
-                  $(Build.ArtifactStagingDirectory)/Unjammit.dmg
+          # - task: Bash@3
+          #   displayName: Create Disk Image
+          #   inputs:
+          #     targetType: inline
+          #     script: |
+          #       echo "Input: Target/$(BuildPlatform)/$(BuildConfiguration)/Unjammit.macOS/Unjammit.app"
+          #       echo "Renaming"
+          #       mv Target/$(BuildPlatform)/$(BuildConfiguration)/Unjammit.macOS/Unjammit.app \
+          #         "Target/$(BuildPlatform)/$(BuildConfiguration)/Unjammit.macOS/Unjammit Alpha.app"
+          #       echo "Output: $(Build.ArtifactStagingDirectory)/Unjammit.dmg"
+          #       hdiutil create -format UDZO \
+          #         -srcfolder "$(Build.SourcesDirectory)/Target/$(BuildPlatform)/$(BuildConfiguration)/Unjammit.macOS/Unjammit Alpha.app" \
+          #         $(Build.ArtifactStagingDirectory)/Unjammit.dmg
 
-          - task: PublishBuildArtifacts@1
-            displayName: 'Publish artifact: macOS-Alpha'
-            inputs:
-              PathtoPublish: $(Build.ArtifactStagingDirectory)
-              ArtifactName: macOS-Alpha
-              publishLocation: Container
+          # - task: PublishBuildArtifacts@1
+          #   displayName: 'Publish artifact: macOS-Alpha'
+          #   inputs:
+          #     PathtoPublish: $(Build.ArtifactStagingDirectory)
+          #     ArtifactName: macOS-Alpha
+          #     publishLocation: Container
 
       # - job:
       #   displayName: iOS

--- a/Scripts/DevOps/Publish.yml
+++ b/Scripts/DevOps/Publish.yml
@@ -80,217 +80,217 @@ stages:
               ArtifactName: macOS-Alpha
               publishLocation: Container
 
-      - job:
-        displayName: iOS
-        dependsOn: SetUp
-
-        variables:
-          - group: Build - iOS
-          - group: Distribute - Alpha - Apple
-          - group: Distribute - Alpha - iOS
-          - name: BuildPlatform
-            value: iPhone
-          - name: BuildConfiguration
-            value: Ad-Hoc
-          - name: BuildVersion
-            value: $[ dependencies.SetUp.outputs['SetBuildVersion.BuildVersion'] ]
-
-        pool:
-          vmImage: $(Job.VmImage)
-
-        steps:
-          - template: Templates/PublishiOSSteps.yml
-            parameters:
-              phase: Alpha
-
-          - task: CopyFiles@2
-            displayName: Stage IPA
-            inputs:
-              SourceFolder: $(Build.SourcesDirectory)/Target/$(BuildPlatform)/$(BuildConfiguration)/Unjammit.iOS/
-              Contents: Unjammit.iOS.ipa
-              TargetFolder: $(Build.ArtifactStagingDirectory)
-
-          - task: PublishBuildArtifacts@1
-            displayName: 'Publish artifact: iOS-Alpha'
-            inputs:
-              PathtoPublish: $(Build.ArtifactStagingDirectory)
-              ArtifactName: iOS-Alpha
-              publishLocation: Container
-
-      - job:
-        displayName: Android
-        dependsOn: SetUp
-
-        variables:
-          - group: Build - Android
-          - group: Distribute - Alpha - Android
-          - name: BuildPlatform
-            value: AnyCPU
-          - name: BuildVersion
-            value: $[ dependencies.SetUp.outputs['SetBuildVersion.BuildVersion'] ]
-
-        pool:
-          vmImage: $(Job.VmImage)
-
-        steps:
-          - template: Templates/PublishAndroidSteps.yml
-            parameters:
-              phase: Alpha
-
-          - task: CopyFiles@2
-            displayName: Stage APK
-            inputs:
-              SourceFolder: $(Build.SourcesDirectory)/Target/$(BuildPlatform)/$(BuildConfiguration)/Unjammit.Android/
-              Contents: $(PackageName).apk
-              TargetFolder: $(Build.ArtifactStagingDirectory)
-
-          - task: PublishBuildArtifacts@1
-            displayName: 'Publish artifact: Android-Alpha'
-            inputs:
-              PathtoPublish: $(Build.ArtifactStagingDirectory)
-              ArtifactName: Android-Alpha
-              publishLocation: Container
-
-      - job:
-        displayName: Windows
-        dependsOn: SetUp
-
-        variables:
-          - group: Build - Windows
-          - group: Distribute - Alpha - Windows
-          - name: BuildPlatform
-            value: x64
-          - name: BuildVersion
-            value: $[ dependencies.SetUp.outputs['SetBuildVersion.BuildVersion'] ]
-
-        pool:
-          vmImage: $(Job.VmImage)
-
-        steps:
-          - template: Templates/PublishWindowsSteps.yml
-            parameters:
-              phase: Alpha
-
-          - task: PublishBuildArtifacts@1
-            displayName: 'Publish artifact: Windows-Alpha'
-            inputs:
-              PathtoPublish: $(Build.StagingDirectory)
-              ArtifactName: Windows-Alpha
-              publishLocation: Container
-
-  - stage: Deploy
-    dependsOn:
-      - Publish
-
-    jobs:
       # - job:
-      #   displayName: Deploy macOS
+      #   displayName: iOS
+      #   dependsOn: SetUp
 
       #   variables:
-      #     - group: Distribute - Alpha - macOS
+      #     - group: Build - iOS
+      #     - group: Distribute - Alpha - Apple
+      #     - group: Distribute - Alpha - iOS
+      #     - name: BuildPlatform
+      #       value: iPhone
+      #     - name: BuildConfiguration
+      #       value: Ad-Hoc
+      #     - name: BuildVersion
+      #       value: $[ dependencies.SetUp.outputs['SetBuildVersion.BuildVersion'] ]
+
+      #   pool:
+      #     vmImage: $(Job.VmImage)
 
       #   steps:
-      #     - checkout: none
+      #     - template: Templates/PublishiOSSteps.yml
+      #       parameters:
+      #         phase: Alpha
 
-      #     - task: DownloadBuildArtifacts@0
-      #       displayName: Download macOS-Alpha
+      #     - task: CopyFiles@2
+      #       displayName: Stage IPA
       #       inputs:
-      #         buildType: current
-      #         artifactName: macOS-Alpha
+      #         SourceFolder: $(Build.SourcesDirectory)/Target/$(BuildPlatform)/$(BuildConfiguration)/Unjammit.iOS/
+      #         Contents: Unjammit.iOS.ipa
+      #         TargetFolder: $(Build.ArtifactStagingDirectory)
 
-      #     - task: AppCenterDistribute@3
-      #       displayName: Distribute in App Center
+      #     - task: PublishBuildArtifacts@1
+      #       displayName: 'Publish artifact: iOS-Alpha'
       #       inputs:
-      #         serverEndpoint: App Center - Hyvart
-      #         appSlug: hyvart/Unjammit-macOS
-      #         appFile: $(System.ArtifactsDirectory)/macOS-Alpha/Unjammit.dmg
-      #         releaseNotesOption: input
-      #         releaseNotesInput: Alpha Build
-      #         isMandatory: true
-      #         destinationType: groups
-      #         distributionGroupId: $(AppCenter.DG.Public),$(AppCenter.DG)
-      #         isSilent: false
+      #         PathtoPublish: $(Build.ArtifactStagingDirectory)
+      #         ArtifactName: iOS-Alpha
+      #         publishLocation: Container
 
-      - job:
-        displayName: Deploy iOS
+      # - job:
+      #   displayName: Android
+      #   dependsOn: SetUp
 
-        variables:
-          - group: Distribute - Alpha - iOS
+      #   variables:
+      #     - group: Build - Android
+      #     - group: Distribute - Alpha - Android
+      #     - name: BuildPlatform
+      #       value: AnyCPU
+      #     - name: BuildVersion
+      #       value: $[ dependencies.SetUp.outputs['SetBuildVersion.BuildVersion'] ]
 
-        steps:
-          - checkout: none
+      #   pool:
+      #     vmImage: $(Job.VmImage)
 
-          - task: DownloadBuildArtifacts@0
-            displayName: Download iOS-Alpha
-            inputs:
-              buildType: current
-              artifactName: iOS-Alpha
+      #   steps:
+      #     - template: Templates/PublishAndroidSteps.yml
+      #       parameters:
+      #         phase: Alpha
 
-          - task: AppCenterDistribute@3
-            displayName: Distribute in App Center
-            inputs:
-              serverEndpoint: App Center - Hyvart
-              appSlug: hyvart/Unjammit
-              appFile: $(System.ArtifactsDirectory)/iOS-Alpha/Unjammit.iOS.ipa
-              releaseNotesOption: input
-              releaseNotesInput: Alpha Build
-              isMandatory: true
-              destinationType: groups
-              distributionGroupId: $(AppCenter.DG.Public),$(AppCenter.DG)
-              isSilent: false
+      #     - task: CopyFiles@2
+      #       displayName: Stage APK
+      #       inputs:
+      #         SourceFolder: $(Build.SourcesDirectory)/Target/$(BuildPlatform)/$(BuildConfiguration)/Unjammit.Android/
+      #         Contents: $(PackageName).apk
+      #         TargetFolder: $(Build.ArtifactStagingDirectory)
 
-      - job:
-        displayName: Deploy Android
+      #     - task: PublishBuildArtifacts@1
+      #       displayName: 'Publish artifact: Android-Alpha'
+      #       inputs:
+      #         PathtoPublish: $(Build.ArtifactStagingDirectory)
+      #         ArtifactName: Android-Alpha
+      #         publishLocation: Container
 
-        variables:
-          - group: Distribute - Alpha - Android
+      # - job:
+      #   displayName: Windows
+      #   dependsOn: SetUp
 
-        steps:
-          - checkout: none
+      #   variables:
+      #     - group: Build - Windows
+      #     - group: Distribute - Alpha - Windows
+      #     - name: BuildPlatform
+      #       value: x64
+      #     - name: BuildVersion
+      #       value: $[ dependencies.SetUp.outputs['SetBuildVersion.BuildVersion'] ]
 
-          - task: DownloadBuildArtifacts@0
-            displayName: Download Android-Alpha
-            inputs:
-              buildType: current
-              artifactName: Android-Alpha
+      #   pool:
+      #     vmImage: $(Job.VmImage)
 
-          - task: AppCenterDistribute@3
-            displayName: Distribute in App Center
-            inputs:
-              serverEndpoint: App Center - Hyvart
-              appSlug: hyvart/Unjammit-Android
-              appFile: $(System.ArtifactsDirectory)/Android-Alpha/$(PackageName).apk
-              releaseNotesOption: input
-              releaseNotesInput: Alpha Build
-              isMandatory: true
-              destinationType: groups
-              distributionGroupId: $(AppCenter.DG.Public),$(AppCenter.DG)
-              isSilent: false
+      #   steps:
+      #     - template: Templates/PublishWindowsSteps.yml
+      #       parameters:
+      #         phase: Alpha
 
-      - job:
-        displayName: Deploy Windows
+      #     - task: PublishBuildArtifacts@1
+      #       displayName: 'Publish artifact: Windows-Alpha'
+      #       inputs:
+      #         PathtoPublish: $(Build.StagingDirectory)
+      #         ArtifactName: Windows-Alpha
+      #         publishLocation: Container
 
-        variables:
-          - group: Distribute - Alpha - Windows
+  # - stage: Deploy
+  #   dependsOn:
+  #     - Publish
 
-        steps:
-          - checkout: none
+  #   jobs:
+  #     # - job:
+  #     #   displayName: Deploy macOS
 
-          - task: DownloadBuildArtifacts@0
-            displayName: Download Windows-Alpha
-            inputs:
-              buildType: current
-              artifactName: Windows-Alpha
+  #     #   variables:
+  #     #     - group: Distribute - Alpha - macOS
 
-          - task: AppCenterDistribute@3
-            displayName: Distribute in App Center
-            inputs:
-              serverEndpoint: App Center - Hyvart
-              appSlug: hyvart/Unjammit-UWP
-              appFile: $(System.ArtifactsDirectory)/Windows-Alpha/AppPackages/*.appxupload
-              releaseNotesOption: input
-              releaseNotesInput: Alpha Build
-              isMandatory: true
-              destinationType: groups
-              distributionGroupId: $(AppCenter.DG.Public),$(AppCenter.DG)
-              isSilent: false
+  #     #   steps:
+  #     #     - checkout: none
+
+  #     #     - task: DownloadBuildArtifacts@0
+  #     #       displayName: Download macOS-Alpha
+  #     #       inputs:
+  #     #         buildType: current
+  #     #         artifactName: macOS-Alpha
+
+  #     #     - task: AppCenterDistribute@3
+  #     #       displayName: Distribute in App Center
+  #     #       inputs:
+  #     #         serverEndpoint: App Center - Hyvart
+  #     #         appSlug: hyvart/Unjammit-macOS
+  #     #         appFile: $(System.ArtifactsDirectory)/macOS-Alpha/Unjammit.dmg
+  #     #         releaseNotesOption: input
+  #     #         releaseNotesInput: Alpha Build
+  #     #         isMandatory: true
+  #     #         destinationType: groups
+  #     #         distributionGroupId: $(AppCenter.DG.Public),$(AppCenter.DG)
+  #     #         isSilent: false
+
+  #     - job:
+  #       displayName: Deploy iOS
+
+  #       variables:
+  #         - group: Distribute - Alpha - iOS
+
+  #       steps:
+  #         - checkout: none
+
+  #         - task: DownloadBuildArtifacts@0
+  #           displayName: Download iOS-Alpha
+  #           inputs:
+  #             buildType: current
+  #             artifactName: iOS-Alpha
+
+  #         - task: AppCenterDistribute@3
+  #           displayName: Distribute in App Center
+  #           inputs:
+  #             serverEndpoint: App Center - Hyvart
+  #             appSlug: hyvart/Unjammit
+  #             appFile: $(System.ArtifactsDirectory)/iOS-Alpha/Unjammit.iOS.ipa
+  #             releaseNotesOption: input
+  #             releaseNotesInput: Alpha Build
+  #             isMandatory: true
+  #             destinationType: groups
+  #             distributionGroupId: $(AppCenter.DG.Public),$(AppCenter.DG)
+  #             isSilent: false
+
+  #     - job:
+  #       displayName: Deploy Android
+
+  #       variables:
+  #         - group: Distribute - Alpha - Android
+
+  #       steps:
+  #         - checkout: none
+
+  #         - task: DownloadBuildArtifacts@0
+  #           displayName: Download Android-Alpha
+  #           inputs:
+  #             buildType: current
+  #             artifactName: Android-Alpha
+
+  #         - task: AppCenterDistribute@3
+  #           displayName: Distribute in App Center
+  #           inputs:
+  #             serverEndpoint: App Center - Hyvart
+  #             appSlug: hyvart/Unjammit-Android
+  #             appFile: $(System.ArtifactsDirectory)/Android-Alpha/$(PackageName).apk
+  #             releaseNotesOption: input
+  #             releaseNotesInput: Alpha Build
+  #             isMandatory: true
+  #             destinationType: groups
+  #             distributionGroupId: $(AppCenter.DG.Public),$(AppCenter.DG)
+  #             isSilent: false
+
+  #     - job:
+  #       displayName: Deploy Windows
+
+  #       variables:
+  #         - group: Distribute - Alpha - Windows
+
+  #       steps:
+  #         - checkout: none
+
+  #         - task: DownloadBuildArtifacts@0
+  #           displayName: Download Windows-Alpha
+  #           inputs:
+  #             buildType: current
+  #             artifactName: Windows-Alpha
+
+  #         - task: AppCenterDistribute@3
+  #           displayName: Distribute in App Center
+  #           inputs:
+  #             serverEndpoint: App Center - Hyvart
+  #             appSlug: hyvart/Unjammit-UWP
+  #             appFile: $(System.ArtifactsDirectory)/Windows-Alpha/AppPackages/*.appxupload
+  #             releaseNotesOption: input
+  #             releaseNotesInput: Alpha Build
+  #             isMandatory: true
+  #             destinationType: groups
+  #             distributionGroupId: $(AppCenter.DG.Public),$(AppCenter.DG)
+  #             isSilent: false

--- a/Scripts/DevOps/Publish.yml
+++ b/Scripts/DevOps/Publish.yml
@@ -55,10 +55,6 @@ stages:
           vmImage: $(Job.VmImage)
 
         steps:
-          - bash: |
-              ls -l /Library/Frameworks/Mono.framework/Versions/
-              ls -l /Library/Frameworks/Xamarin.Mac.framework/Versions/
-
           - template: Templates/PublishMacOSSteps.yml
             parameters:
               phase: Alpha
@@ -84,217 +80,217 @@ stages:
               ArtifactName: macOS-Alpha
               publishLocation: Container
 
+      - job:
+        displayName: iOS
+        dependsOn: SetUp
+
+        variables:
+          - group: Build - iOS
+          - group: Distribute - Alpha - Apple
+          - group: Distribute - Alpha - iOS
+          - name: BuildPlatform
+            value: iPhone
+          - name: BuildConfiguration
+            value: Ad-Hoc
+          - name: BuildVersion
+            value: $[ dependencies.SetUp.outputs['SetBuildVersion.BuildVersion'] ]
+
+        pool:
+          vmImage: $(Job.VmImage)
+
+        steps:
+          - template: Templates/PublishiOSSteps.yml
+            parameters:
+              phase: Alpha
+
+          - task: CopyFiles@2
+            displayName: Stage IPA
+            inputs:
+              SourceFolder: $(Build.SourcesDirectory)/Target/$(BuildPlatform)/$(BuildConfiguration)/Unjammit.iOS/
+              Contents: Unjammit.iOS.ipa
+              TargetFolder: $(Build.ArtifactStagingDirectory)
+
+          - task: PublishBuildArtifacts@1
+            displayName: 'Publish artifact: iOS-Alpha'
+            inputs:
+              PathtoPublish: $(Build.ArtifactStagingDirectory)
+              ArtifactName: iOS-Alpha
+              publishLocation: Container
+
+      - job:
+        displayName: Android
+        dependsOn: SetUp
+
+        variables:
+          - group: Build - Android
+          - group: Distribute - Alpha - Android
+          - name: BuildPlatform
+            value: AnyCPU
+          - name: BuildVersion
+            value: $[ dependencies.SetUp.outputs['SetBuildVersion.BuildVersion'] ]
+
+        pool:
+          vmImage: $(Job.VmImage)
+
+        steps:
+          - template: Templates/PublishAndroidSteps.yml
+            parameters:
+              phase: Alpha
+
+          - task: CopyFiles@2
+            displayName: Stage APK
+            inputs:
+              SourceFolder: $(Build.SourcesDirectory)/Target/$(BuildPlatform)/$(BuildConfiguration)/Unjammit.Android/
+              Contents: $(PackageName).apk
+              TargetFolder: $(Build.ArtifactStagingDirectory)
+
+          - task: PublishBuildArtifacts@1
+            displayName: 'Publish artifact: Android-Alpha'
+            inputs:
+              PathtoPublish: $(Build.ArtifactStagingDirectory)
+              ArtifactName: Android-Alpha
+              publishLocation: Container
+
+      - job:
+        displayName: Windows
+        dependsOn: SetUp
+
+        variables:
+          - group: Build - Windows
+          - group: Distribute - Alpha - Windows
+          - name: BuildPlatform
+            value: x64
+          - name: BuildVersion
+            value: $[ dependencies.SetUp.outputs['SetBuildVersion.BuildVersion'] ]
+
+        pool:
+          vmImage: $(Job.VmImage)
+
+        steps:
+          - template: Templates/PublishWindowsSteps.yml
+            parameters:
+              phase: Alpha
+
+          - task: PublishBuildArtifacts@1
+            displayName: 'Publish artifact: Windows-Alpha'
+            inputs:
+              PathtoPublish: $(Build.StagingDirectory)
+              ArtifactName: Windows-Alpha
+              publishLocation: Container
+
+  - stage: Deploy
+    dependsOn:
+      - Publish
+
+    jobs:
       # - job:
-      #   displayName: iOS
-      #   dependsOn: SetUp
+      #   displayName: Deploy macOS
 
       #   variables:
-      #     - group: Build - iOS
-      #     - group: Distribute - Alpha - Apple
-      #     - group: Distribute - Alpha - iOS
-      #     - name: BuildPlatform
-      #       value: iPhone
-      #     - name: BuildConfiguration
-      #       value: Ad-Hoc
-      #     - name: BuildVersion
-      #       value: $[ dependencies.SetUp.outputs['SetBuildVersion.BuildVersion'] ]
-
-      #   pool:
-      #     vmImage: $(Job.VmImage)
+      #     - group: Distribute - Alpha - macOS
 
       #   steps:
-      #     - template: Templates/PublishiOSSteps.yml
-      #       parameters:
-      #         phase: Alpha
+      #     - checkout: none
 
-      #     - task: CopyFiles@2
-      #       displayName: Stage IPA
+      #     - task: DownloadBuildArtifacts@0
+      #       displayName: Download macOS-Alpha
       #       inputs:
-      #         SourceFolder: $(Build.SourcesDirectory)/Target/$(BuildPlatform)/$(BuildConfiguration)/Unjammit.iOS/
-      #         Contents: Unjammit.iOS.ipa
-      #         TargetFolder: $(Build.ArtifactStagingDirectory)
+      #         buildType: current
+      #         artifactName: macOS-Alpha
 
-      #     - task: PublishBuildArtifacts@1
-      #       displayName: 'Publish artifact: iOS-Alpha'
+      #     - task: AppCenterDistribute@3
+      #       displayName: Distribute in App Center
       #       inputs:
-      #         PathtoPublish: $(Build.ArtifactStagingDirectory)
-      #         ArtifactName: iOS-Alpha
-      #         publishLocation: Container
+      #         serverEndpoint: App Center - Hyvart
+      #         appSlug: hyvart/Unjammit-macOS
+      #         appFile: $(System.ArtifactsDirectory)/macOS-Alpha/Unjammit.dmg
+      #         releaseNotesOption: input
+      #         releaseNotesInput: Alpha Build
+      #         isMandatory: true
+      #         destinationType: groups
+      #         distributionGroupId: $(AppCenter.DG.Public),$(AppCenter.DG)
+      #         isSilent: false
 
-      # - job:
-      #   displayName: Android
-      #   dependsOn: SetUp
+      - job:
+        displayName: Deploy iOS
 
-      #   variables:
-      #     - group: Build - Android
-      #     - group: Distribute - Alpha - Android
-      #     - name: BuildPlatform
-      #       value: AnyCPU
-      #     - name: BuildVersion
-      #       value: $[ dependencies.SetUp.outputs['SetBuildVersion.BuildVersion'] ]
+        variables:
+          - group: Distribute - Alpha - iOS
 
-      #   pool:
-      #     vmImage: $(Job.VmImage)
+        steps:
+          - checkout: none
 
-      #   steps:
-      #     - template: Templates/PublishAndroidSteps.yml
-      #       parameters:
-      #         phase: Alpha
+          - task: DownloadBuildArtifacts@0
+            displayName: Download iOS-Alpha
+            inputs:
+              buildType: current
+              artifactName: iOS-Alpha
 
-      #     - task: CopyFiles@2
-      #       displayName: Stage APK
-      #       inputs:
-      #         SourceFolder: $(Build.SourcesDirectory)/Target/$(BuildPlatform)/$(BuildConfiguration)/Unjammit.Android/
-      #         Contents: $(PackageName).apk
-      #         TargetFolder: $(Build.ArtifactStagingDirectory)
+          - task: AppCenterDistribute@3
+            displayName: Distribute in App Center
+            inputs:
+              serverEndpoint: App Center - Hyvart
+              appSlug: hyvart/Unjammit
+              appFile: $(System.ArtifactsDirectory)/iOS-Alpha/Unjammit.iOS.ipa
+              releaseNotesOption: input
+              releaseNotesInput: Alpha Build
+              isMandatory: true
+              destinationType: groups
+              distributionGroupId: $(AppCenter.DG.Public),$(AppCenter.DG)
+              isSilent: false
 
-      #     - task: PublishBuildArtifacts@1
-      #       displayName: 'Publish artifact: Android-Alpha'
-      #       inputs:
-      #         PathtoPublish: $(Build.ArtifactStagingDirectory)
-      #         ArtifactName: Android-Alpha
-      #         publishLocation: Container
+      - job:
+        displayName: Deploy Android
 
-      # - job:
-      #   displayName: Windows
-      #   dependsOn: SetUp
+        variables:
+          - group: Distribute - Alpha - Android
 
-      #   variables:
-      #     - group: Build - Windows
-      #     - group: Distribute - Alpha - Windows
-      #     - name: BuildPlatform
-      #       value: x64
-      #     - name: BuildVersion
-      #       value: $[ dependencies.SetUp.outputs['SetBuildVersion.BuildVersion'] ]
+        steps:
+          - checkout: none
 
-      #   pool:
-      #     vmImage: $(Job.VmImage)
+          - task: DownloadBuildArtifacts@0
+            displayName: Download Android-Alpha
+            inputs:
+              buildType: current
+              artifactName: Android-Alpha
 
-      #   steps:
-      #     - template: Templates/PublishWindowsSteps.yml
-      #       parameters:
-      #         phase: Alpha
+          - task: AppCenterDistribute@3
+            displayName: Distribute in App Center
+            inputs:
+              serverEndpoint: App Center - Hyvart
+              appSlug: hyvart/Unjammit-Android
+              appFile: $(System.ArtifactsDirectory)/Android-Alpha/$(PackageName).apk
+              releaseNotesOption: input
+              releaseNotesInput: Alpha Build
+              isMandatory: true
+              destinationType: groups
+              distributionGroupId: $(AppCenter.DG.Public),$(AppCenter.DG)
+              isSilent: false
 
-      #     - task: PublishBuildArtifacts@1
-      #       displayName: 'Publish artifact: Windows-Alpha'
-      #       inputs:
-      #         PathtoPublish: $(Build.StagingDirectory)
-      #         ArtifactName: Windows-Alpha
-      #         publishLocation: Container
+      - job:
+        displayName: Deploy Windows
 
-  # - stage: Deploy
-  #   dependsOn:
-  #     - Publish
+        variables:
+          - group: Distribute - Alpha - Windows
 
-  #   jobs:
-  #     # - job:
-  #     #   displayName: Deploy macOS
+        steps:
+          - checkout: none
 
-  #     #   variables:
-  #     #     - group: Distribute - Alpha - macOS
+          - task: DownloadBuildArtifacts@0
+            displayName: Download Windows-Alpha
+            inputs:
+              buildType: current
+              artifactName: Windows-Alpha
 
-  #     #   steps:
-  #     #     - checkout: none
-
-  #     #     - task: DownloadBuildArtifacts@0
-  #     #       displayName: Download macOS-Alpha
-  #     #       inputs:
-  #     #         buildType: current
-  #     #         artifactName: macOS-Alpha
-
-  #     #     - task: AppCenterDistribute@3
-  #     #       displayName: Distribute in App Center
-  #     #       inputs:
-  #     #         serverEndpoint: App Center - Hyvart
-  #     #         appSlug: hyvart/Unjammit-macOS
-  #     #         appFile: $(System.ArtifactsDirectory)/macOS-Alpha/Unjammit.dmg
-  #     #         releaseNotesOption: input
-  #     #         releaseNotesInput: Alpha Build
-  #     #         isMandatory: true
-  #     #         destinationType: groups
-  #     #         distributionGroupId: $(AppCenter.DG.Public),$(AppCenter.DG)
-  #     #         isSilent: false
-
-  #     - job:
-  #       displayName: Deploy iOS
-
-  #       variables:
-  #         - group: Distribute - Alpha - iOS
-
-  #       steps:
-  #         - checkout: none
-
-  #         - task: DownloadBuildArtifacts@0
-  #           displayName: Download iOS-Alpha
-  #           inputs:
-  #             buildType: current
-  #             artifactName: iOS-Alpha
-
-  #         - task: AppCenterDistribute@3
-  #           displayName: Distribute in App Center
-  #           inputs:
-  #             serverEndpoint: App Center - Hyvart
-  #             appSlug: hyvart/Unjammit
-  #             appFile: $(System.ArtifactsDirectory)/iOS-Alpha/Unjammit.iOS.ipa
-  #             releaseNotesOption: input
-  #             releaseNotesInput: Alpha Build
-  #             isMandatory: true
-  #             destinationType: groups
-  #             distributionGroupId: $(AppCenter.DG.Public),$(AppCenter.DG)
-  #             isSilent: false
-
-  #     - job:
-  #       displayName: Deploy Android
-
-  #       variables:
-  #         - group: Distribute - Alpha - Android
-
-  #       steps:
-  #         - checkout: none
-
-  #         - task: DownloadBuildArtifacts@0
-  #           displayName: Download Android-Alpha
-  #           inputs:
-  #             buildType: current
-  #             artifactName: Android-Alpha
-
-  #         - task: AppCenterDistribute@3
-  #           displayName: Distribute in App Center
-  #           inputs:
-  #             serverEndpoint: App Center - Hyvart
-  #             appSlug: hyvart/Unjammit-Android
-  #             appFile: $(System.ArtifactsDirectory)/Android-Alpha/$(PackageName).apk
-  #             releaseNotesOption: input
-  #             releaseNotesInput: Alpha Build
-  #             isMandatory: true
-  #             destinationType: groups
-  #             distributionGroupId: $(AppCenter.DG.Public),$(AppCenter.DG)
-  #             isSilent: false
-
-  #     - job:
-  #       displayName: Deploy Windows
-
-  #       variables:
-  #         - group: Distribute - Alpha - Windows
-
-  #       steps:
-  #         - checkout: none
-
-  #         - task: DownloadBuildArtifacts@0
-  #           displayName: Download Windows-Alpha
-  #           inputs:
-  #             buildType: current
-  #             artifactName: Windows-Alpha
-
-  #         - task: AppCenterDistribute@3
-  #           displayName: Distribute in App Center
-  #           inputs:
-  #             serverEndpoint: App Center - Hyvart
-  #             appSlug: hyvart/Unjammit-UWP
-  #             appFile: $(System.ArtifactsDirectory)/Windows-Alpha/AppPackages/*.appxupload
-  #             releaseNotesOption: input
-  #             releaseNotesInput: Alpha Build
-  #             isMandatory: true
-  #             destinationType: groups
-  #             distributionGroupId: $(AppCenter.DG.Public),$(AppCenter.DG)
-  #             isSilent: false
+          - task: AppCenterDistribute@3
+            displayName: Distribute in App Center
+            inputs:
+              serverEndpoint: App Center - Hyvart
+              appSlug: hyvart/Unjammit-UWP
+              appFile: $(System.ArtifactsDirectory)/Windows-Alpha/AppPackages/*.appxupload
+              releaseNotesOption: input
+              releaseNotesInput: Alpha Build
+              isMandatory: true
+              destinationType: groups
+              distributionGroupId: $(AppCenter.DG.Public),$(AppCenter.DG)
+              isSilent: false

--- a/Scripts/DevOps/Templates/BuildMacOSSteps.yml
+++ b/Scripts/DevOps/Templates/BuildMacOSSteps.yml
@@ -10,10 +10,13 @@ parameters:
   debug: false
 
 steps:
-  - template: SetMacOSFrameworkVersion.yml
-    parameters:
-      framework: Mono
-      version: 5.18.1
+  # - template: SetMacOSFrameworkVersion.yml
+  #   parameters:
+  #     framework: Mono
+  #     version: 6.0.0
+  - bash: |
+      /bin/bash -c "sudo $AGENT_HOMEDIRECTORY/scripts/select-xamarin-sdk.sh 6_4_0"
+
 
   - task: DotNetCoreInstaller@1
     displayName: Install .NET Core $(DotNetCoreSdk.Version)

--- a/Scripts/DevOps/Templates/BuildMacOSSteps.yml
+++ b/Scripts/DevOps/Templates/BuildMacOSSteps.yml
@@ -10,10 +10,10 @@ parameters:
   debug: false
 
 steps:
-  # - template: SetMacOSFrameworkVersion.yml
-  #   parameters:
-  #     framework: Mono
-  #     version: $(XamarinMac.MonoVersion)
+  - template: SetMacOSFrameworkVersion.yml
+    parameters:
+      framework: Mono
+      version: 5.18.1
 
   - task: DotNetCoreInstaller@1
     displayName: Install .NET Core $(DotNetCoreSdk.Version)

--- a/Scripts/DevOps/Templates/BuildMacOSSteps.yml
+++ b/Scripts/DevOps/Templates/BuildMacOSSteps.yml
@@ -13,9 +13,10 @@ steps:
   # - template: SetMacOSFrameworkVersion.yml
   #   parameters:
   #     framework: Mono
-  #     version: 6.0.0
+  #     version: $(XamarinMac.MonoVersion)
   - bash: |
-      /bin/bash -c "sudo $AGENT_HOMEDIRECTORY/scripts/select-xamarin-sdk.sh 6_4_0"
+      /bin/bash -c "sudo $AGENT_HOMEDIRECTORY/scripts/select-xamarin-sdk.sh ${XAMARINMAC_MONOVERSION}"
+    displayName: Set Xamarin version set to $(XamarinMac.MonoVersion)
 
 
   - task: DotNetCoreInstaller@1

--- a/Scripts/DevOps/Templates/BuildMacOSSteps.yml
+++ b/Scripts/DevOps/Templates/BuildMacOSSteps.yml
@@ -10,10 +10,10 @@ parameters:
   debug: false
 
 steps:
-  - template: SetMacOSFrameworkVersion.yml
-    parameters:
-      framework: Mono
-      version: $(XamarinMac.MonoVersion)
+  # - template: SetMacOSFrameworkVersion.yml
+  #   parameters:
+  #     framework: Mono
+  #     version: $(XamarinMac.MonoVersion)
 
   - task: DotNetCoreInstaller@1
     displayName: Install .NET Core $(DotNetCoreSdk.Version)

--- a/Scripts/DevOps/Templates/BuildiOSSteps.yml
+++ b/Scripts/DevOps/Templates/BuildiOSSteps.yml
@@ -16,10 +16,14 @@ parameters:
   debug: false
 
 steps:
-  - template: SetMacOSFrameworkVersion.yml
-    parameters:
-      framework: Mono
-      version: $(XamariniOS.MonoVersion)
+  # - template: SetMacOSFrameworkVersion.yml
+  #   parameters:
+  #     framework: Mono
+  #     version: $(XamariniOS.MonoVersion)
+  - bash: |
+      /bin/bash -c "sudo $AGENT_HOMEDIRECTORY/scripts/select-xamarin-sdk.sh ${XAMARINIOS_MONOVERSION}"
+    displayName: Set Xamarin version set to $(XamariniOS.MonoVersion)
+
 
   - task: DotNetCoreInstaller@1
     inputs:


### PR DESCRIPTION
Instead of custom symlink overrides, use the convenience script `$AGENT_HOMEDIRECTORY/scripts/select-xamarin-sdk.sh` to set the Xamarin+Mono versions for Apple builds.

Note, the version format changes from `X.Y.Z` to `X_Y_Z`.