### PR TITLE
Work around Xamarin.Essentials Preferences in GTK.

### DIFF
--- a/Forms/Settings.cs
+++ b/Forms/Settings.cs
@@ -1,4 +1,6 @@
-﻿using Xamarin.Essentials;
+﻿using System.Collections.Generic;
+
+using Xamarin.Essentials;
 
 namespace Jammit.Forms
 {
@@ -9,6 +11,8 @@ namespace Jammit.Forms
   /// </summary>
   public static class Settings
   {
+    private static Dictionary<string, object> _prefMap = new Dictionary<string, object>();
+
     #region Setting Constants
 
     private const string SettingsKey = "settings_key";
@@ -64,7 +68,14 @@ namespace Jammit.Forms
 
     public static void Clear()
     {
-      Preferences.Clear();
+      try
+      {
+        Preferences.Clear();
+      }
+      catch(NotImplementedInReferenceAssemblyException)
+      {
+        _prefMap.Clear();
+      }
     }
 
     public static string GeneralSettings
@@ -83,12 +94,32 @@ namespace Jammit.Forms
     {
       get
       {
-        return Preferences.Get(TrackPathKey, TrackPathDefault);
+        try
+        {
+          return Preferences.Get(TrackPathKey, TrackPathDefault);
+        }
+        catch(NotImplementedInReferenceAssemblyException)
+        {
+          object result;
+          if (_prefMap.TryGetValue(TrackPathKey, out result))
+          {
+            return result as string;
+          }
+
+          return TrackPathDefault;
+        }
       }
 
       set
       {
-        Preferences.Set(TrackPathKey, value);
+        try
+        {
+          Preferences.Set(TrackPathKey, value);
+        }
+        catch(NotImplementedInReferenceAssemblyException)
+        {
+          _prefMap[TrackPathKey] = value;
+        }
       }
     }
 
@@ -96,12 +127,32 @@ namespace Jammit.Forms
     {
       get
       {
-        return Preferences.Get(ServiceUriKey, ServiceUriDefault);
+        try
+        {
+          return Preferences.Get(ServiceUriKey, ServiceUriDefault);
+        }
+        catch(NotImplementedInReferenceAssemblyException)
+        {
+          object result;
+          if (_prefMap.TryGetValue(ServiceUriKey, out result))
+          {
+            return result as string;
+          }
+
+          return ServiceUriDefault;
+        }
       }
 
       set
       {
-        Preferences.Set(ServiceUriKey, value);
+        try
+        {
+          Preferences.Set(ServiceUriKey, value);
+        }
+        catch (NotImplementedInReferenceAssemblyException)
+        {
+          _prefMap[ServiceUriKey] = value;
+        }
       }
     }
 
@@ -109,12 +160,30 @@ namespace Jammit.Forms
     {
       get
       {
-        return Preferences.Get(CredentialsKey, CredentialsDefault);
+        try
+        {
+          return Preferences.Get(CredentialsKey, CredentialsDefault);
+        }
+        catch (NotImplementedInReferenceAssemblyException)
+        {
+          object result;
+          if (_prefMap.TryGetValue(CredentialsKey, out result))
+            return result as string;
+
+          return CredentialsDefault;
+        }
       }
 
       set
       {
-        Preferences.Set(CredentialsKey, value);
+        try
+        {
+          Preferences.Set(CredentialsKey, value);
+        }
+        catch (NotImplementedInReferenceAssemblyException)
+        {
+          _prefMap[CredentialsKey] = value;
+        }
       }
     }
 
@@ -122,12 +191,26 @@ namespace Jammit.Forms
     {
       get
       {
-        return Preferences.Get(CultureKey, CultureDefault);
+        try
+        {
+          return Preferences.Get(CultureKey, CultureDefault);
+        }
+        catch (NotImplementedInReferenceAssemblyException)
+        {
+          return CultureDefault;
+        }
       }
 
       set
       {
-        Preferences.Set(CultureKey, value);
+        try
+        {
+          Preferences.Set(CultureKey, value);
+        }
+        catch (NotImplementedInReferenceAssemblyException)
+        {
+          _prefMap[CultureKey] = value;
+        }
       }
     }
 
@@ -135,52 +218,120 @@ namespace Jammit.Forms
 
     public static bool Get(string key, bool defaultValue)
     {
-      return Preferences.Get(key, defaultValue);
+      try
+      {
+        return Preferences.Get(key, defaultValue);
+      }
+      catch(NotImplementedInReferenceAssemblyException)
+      {
+        return defaultValue;
+      }
     }
 
     public static void Set(string key, bool value)
     {
-      Preferences.Set(key, value);
+      try
+      {
+        Preferences.Set(key, value);
+      }
+      catch(NotImplementedInReferenceAssemblyException)
+      {
+      }
     }
 
     public static uint Get(string key, uint defaultValue)
     {
-      return (uint)Preferences.Get(key, (long)defaultValue);
+      try
+      {
+        return (uint)Preferences.Get(key, (long)defaultValue);
+      }
+      catch(NotImplementedInReferenceAssemblyException)
+      {
+        return defaultValue;
+      }
     }
 
     public static void Set(string key, uint value)
     {
-      Preferences.Set(key, (long)value);
+      try
+      {
+        Preferences.Set(key, (long)value);
+      }
+      catch(NotImplementedInReferenceAssemblyException)
+      {
+
+      }
     }
 
     public static float Get(string key, float defaultValue)
     {
-      return Preferences.Get(key, defaultValue);
+      try
+      {
+        return Preferences.Get(key, defaultValue);
+      }
+      catch(NotImplementedInReferenceAssemblyException)
+      {
+        return defaultValue;
+      }
     }
 
     public static void Set(string key, float value)
     {
-      Preferences.Set(key, value);
+      try
+      {
+        Preferences.Set(key, value);
+      }
+      catch(NotImplementedInReferenceAssemblyException)
+      {
+
+      }
     }
 
     public static string Get(string key, string defaultValue)
     {
-      return Preferences.Get(key, defaultValue);
+      try
+      {
+        return Preferences.Get(key, defaultValue);
+      }
+      catch(NotImplementedInReferenceAssemblyException)
+      {
+        return defaultValue;
+      }
     }
 
     public static void Set(string key, string value)
     {
-      Preferences.Set(key, value);
+      try
+      {
+        Preferences.Set(key, value);
+      }
+      catch(NotImplementedInReferenceAssemblyException)
+      {
+
+      }
     }
 
     public static System.TimeSpan Get(string key, System.TimeSpan defaultValue)
     {
-      return System.TimeSpan.FromMilliseconds(Preferences.Get(key, defaultValue.TotalMilliseconds));
+      try
+      {
+        return System.TimeSpan.FromMilliseconds(Preferences.Get(key, defaultValue.TotalMilliseconds));
+      }
+      catch(NotImplementedInReferenceAssemblyException)
+      {
+        return defaultValue;
+      }
     }
 
     public static void Set(string key, System.TimeSpan value)
     {
-      Preferences.Set(key, value.TotalMilliseconds);
+      try
+      {
+        Preferences.Set(key, value.TotalMilliseconds);
+      }
+      catch(NotImplementedInReferenceAssemblyException)
+      {
+      }
     }
 
     #endregion Generic settings

--- a/Forms/Unjammit.Forms.csproj
+++ b/Forms/Unjammit.Forms.csproj
@@ -49,12 +49,6 @@
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Localized.Designer.cs</LastGenOutput>
     </EmbeddedResource>
-    <EmbeddedResource Update="Views\MainPage.xaml">
-      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
-    </EmbeddedResource>
-    <EmbeddedResource Update="Views\MenuPage.xaml">
-      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
-    </EmbeddedResource>
   </ItemGroup>
 
 </Project>

--- a/Forms/Views/MenuPage.xaml
+++ b/Forms/Views/MenuPage.xaml
@@ -6,6 +6,7 @@
              xmlns:xaml="clr-namespace:Jammit.Forms.Xaml"
              x:Class="Jammit.Forms.Views.MenuPage"
              Title="{OnPlatform Default={xaml:TranslateTitle MenuPage_Title}}">
+             <!--TODO: OnPlatform Default helps non-supported platforms set the value (i.e. GTK).-->
   <StackLayout VerticalOptions="FillAndExpand">
     <ListView x:Name="MenuListView" x:FieldModifier="public">
       <ListView.ItemsSource>

--- a/Forms/Views/MenuPage.xaml
+++ b/Forms/Views/MenuPage.xaml
@@ -5,7 +5,7 @@
              xmlns:models="clr-namespace:Jammit.Forms.Models"
              xmlns:xaml="clr-namespace:Jammit.Forms.Xaml"
              x:Class="Jammit.Forms.Views.MenuPage"
-             Title="{xaml:TranslateTitle MenuPage_Title}">
+             Title="{OnPlatform Default={xaml:TranslateTitle MenuPage_Title}}">
   <StackLayout VerticalOptions="FillAndExpand">
     <ListView x:Name="MenuListView" x:FieldModifier="public">
       <ListView.ItemsSource>

--- a/Forms/Views/SettingsPage.xaml
+++ b/Forms/Views/SettingsPage.xaml
@@ -46,6 +46,9 @@
         </StackLayout>
       </StackLayout>
     </Grid>
+    <Button x:Name="SaveSettingsButton" Text="Save Settings"
+            IsVisible="{OnPlatform GTK=true, Default=false}"
+            Clicked="SaveSettingsButton_Clicked" />
     <Button x:Name="DeleteDataButton" Text="{xaml:TranslateText SettingsPage_DeleteDataButton}" Clicked="DeleteDataButton_Clicked" />
   </StackLayout>
 

--- a/Forms/Views/SettingsPage.xaml.cs
+++ b/Forms/Views/SettingsPage.xaml.cs
@@ -153,5 +153,17 @@ namespace Jammit.Forms.Views
         Settings.Clear();
       }
     }
+
+    /// <summary>
+    /// Excplicitly saves settings.
+    /// 
+    /// TODO: Remove when GTK focus/unfocus events are supported.
+    /// </summary>
+    /// <param name="sender">Save button</param>
+    /// <param name="e">No purpose</param>
+    private void SaveSettingsButton_Clicked(object sender, EventArgs e)
+    {
+      Settings.ServiceUri = ServiceUriEntry.Text;
+    }
   }
 }

--- a/Forms/Views/TrackSlider.xaml.cs
+++ b/Forms/Views/TrackSlider.xaml.cs
@@ -113,6 +113,9 @@ namespace Jammit.Forms.Views
 
     private void VolumeSlider_ValueChanged(object sender, ValueChangedEventArgs e)
     {
+      if (!IsEnabled)
+        return;
+
       //TODO: How about setting the track volume right here and drop the Volume property?
       if (State.Muted != _state)
       {

--- a/Scripts/DevOps/Templates/MSBuildSteps.yml
+++ b/Scripts/DevOps/Templates/MSBuildSteps.yml
@@ -33,7 +33,7 @@ steps:
   - task: NuGetCommand@2
     inputs:
       command: custom
-      arguments: sources Add -Name "nuget.org" -Source https://api.nuget.org/v3/index.json
+      arguments: sources Enable -Name "nuget.org"
 
   - task: MSBuild@1
     displayName: Restore Packages

--- a/Scripts/DevOps/Templates/MSBuildSteps.yml
+++ b/Scripts/DevOps/Templates/MSBuildSteps.yml
@@ -30,6 +30,11 @@ steps:
       packageType: sdk
       version: $(DotNetCoreSdk.Version)
 
+  - task: NuGetCommand@2
+    inputs:
+      command: custom
+      arguments: sources Add -Name "nuget.org" -Source https://api.nuget.org/v3/index.json
+
   - task: MSBuild@1
     displayName: Restore Packages
     inputs:


### PR DESCRIPTION
Use non-persistent settings and avoid crashing on GTK due to lack of Xamarin.Essentials support.