### PR TITLE
Use SKU as SongInfo identifier

### DIFF
--- a/Core/Model/FileSystemJcfLoader.cs
+++ b/Core/Model/FileSystemJcfLoader.cs
@@ -18,10 +18,9 @@ namespace Jammit.Model
 
     #region IJcfLoader members
 
-    public JcfMedia LoadMedia(Model.SongInfo song)
+    public JcfMedia LoadMedia(SongInfo song)
     {
-      string tracksPath = Path.Combine(dataDirectory, "Tracks");
-      string songPath = Path.Combine(dataDirectory, "Tracks", $"{song.Id}".ToUpper() + ".jcf");
+      string songPath = Path.Combine(dataDirectory, "Tracks", $"{song.Sku}" + ".jcf");
 
       var result = new JcfMedia(song, songPath);
 

--- a/Core/Model/FolderLibrary.cs
+++ b/Core/Model/FolderLibrary.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.IO;
@@ -46,7 +46,7 @@ namespace Jammit.Model
     {
       return new SongInfo
       {
-        Sku = xe.Attribute("sku").Value,
+        Sku = xe.Element("sku").Value,
         Artist = xe.Element("artist").Value,
         Album = xe.Element("album").Value,
         Title = xe.Element("title").Value,
@@ -148,8 +148,9 @@ namespace Jammit.Model
           });
         }
 
-        var entryPath = infoEntry.FullName.Remove(infoEntry.FullName.IndexOf("info.plist"));
-        foreach (var entry in archive.Entries.Where(e => e.FullName.StartsWith(entryPath)))
+        var entryPath = infoEntry.FullName.Remove(infoEntry.FullName.IndexOf("info.plist", StringComparison.Ordinal));
+        foreach (var entry in archive.Entries.Where(e =>
+          e.FullName.StartsWith(entryPath, StringComparison.Ordinal) &! e.FullName.EndsWith("/", StringComparison.Ordinal)))
         {
           entry.ExtractToFile(Path.Combine(songDir.FullName, entry.Name));
         }

--- a/Core/Model/ILibrary.cs
+++ b/Core/Model/ILibrary.cs
@@ -10,9 +10,6 @@ namespace Jammit.Model
   {
     List<SongInfo> Songs { get; }
 
-    [Obsolete("Use AddSong(System.IO.Stream) instead.")]
-    Task AddSong(SongInfo song);
-
     SongInfo AddSong(System.IO.Stream conentStream);
 
     void RemoveSong(SongInfo song);

--- a/Core/Model/JcfMedia.cs
+++ b/Core/Model/JcfMedia.cs
@@ -44,7 +44,7 @@ namespace Jammit.Model
 
     public int CompareTo(JcfMedia other)
     {
-      return Song.Id.CompareTo(other.Song.Id);
+      return Song.Sku.CompareTo(other.Song.Sku);
     }
 
     #endregion

--- a/Core/Model/SongInfo.cs
+++ b/Core/Model/SongInfo.cs
@@ -7,8 +7,7 @@ namespace Jammit.Model
   {
     public SongInfo() { }
 
-    public Guid Id { get; set; }
-    public string Sku { get; set; }
+    public string Sku { get; set; } // ID
     public string Artist { get; set; }
     public string Album { get; set; }
     public string Title { get; set; }

--- a/Forms/Client/BasicHttpClient.cs
+++ b/Forms/Client/BasicHttpClient.cs
@@ -101,7 +101,7 @@ namespace Jammit.Forms.Client
           //TODO
         };
 
-        var uri = new Uri($"{Settings.ServiceUri}/{song.Id.ToString().ToUpper()}.zip");
+        var uri = new Uri($"{Settings.ServiceUri}/{song.Sku}");
         await client.DownloadFileTaskAsync(uri, path);
       }
     }
@@ -137,7 +137,6 @@ namespace Jammit.Forms.Client
           {
             result.Add(new SongInfo()
             {
-              Id = Guid.Parse(song["id"].ToString()),
               Sku = song["sku"].ToString(),
               Artist = song["artist"].ToString(),
               Album = song["album"].ToString(),

--- a/Forms/Client/BasicHttpClient.cs
+++ b/Forms/Client/BasicHttpClient.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.IO;
@@ -101,7 +101,7 @@ namespace Jammit.Forms.Client
           //TODO
         };
 
-        var uri = new Uri($"{Settings.ServiceUri}/{song.Sku}");
+        var uri = new Uri($"{Settings.ServiceUri}/jcf/{song.Sku}");
         await client.DownloadFileTaskAsync(uri, path);
       }
     }

--- a/Forms/Client/RestClient.cs
+++ b/Forms/Client/RestClient.cs
@@ -50,7 +50,6 @@ namespace Jammit.Forms.Client
           {
             result.Add(new SongInfo()
             {
-              Id = Guid.Parse(song["id"].ToString()),
               Sku = song["sku"].ToString(),
               Artist = song["artist"].ToString(),
               Album = song["album"].ToString(),
@@ -91,7 +90,7 @@ namespace Jammit.Forms.Client
       // https://stackoverflow.com/questions/36698677
       using (var client = new HttpClient(new HttpClientHandler(), false))
       {
-        client.BaseAddress = new Uri($"{Settings.ServiceUri}/download?id={song.Id.ToString().ToUpper()}");
+        client.BaseAddress = new Uri($"{Settings.ServiceUri}/download?id={song.Sku}");
         client.DefaultRequestHeaders.Clear();
 
         var response = await client.GetAsync(client.BaseAddress.AbsoluteUri);
@@ -133,7 +132,7 @@ namespace Jammit.Forms.Client
           //TODO
         };
 
-        var uri = new Uri($"{Settings.ServiceUri}/download?id={song.Id.ToString().ToUpper()}");
+        var uri = new Uri($"{Settings.ServiceUri}/download?id={song.Sku}");
         await client.DownloadFileTaskAsync(uri, path);
       }
     }

--- a/Forms/Settings.cs
+++ b/Forms/Settings.cs
@@ -36,12 +36,12 @@ namespace Jammit.Forms
 
     public static string SelectedScoreKey(Model.SongInfo song)
     {
-      return $"Song/{song.Id}/SelectedScore";
+      return $"Song/{song.Sku}/SelectedScore";
     }
 
     public static string MixerCollapsedKey(Model.SongInfo song)
     {
-      return $"Song/{song.Id}/MixerCollapsed";
+      return $"Song/{song.Sku}/MixerCollapsed";
     }
 
     public static string TrackVolumeKey(Model.TrackInfo track)
@@ -61,7 +61,7 @@ namespace Jammit.Forms
 
     public static string PositionKey(Model.SongInfo song)
     {
-      return $"Song/{song.Id}/Position";
+      return $"Song/{song.Sku}/Position";
     }
 
     #endregion Settings Functions

--- a/Forms/Views/CatalogPage.xaml.cs
+++ b/Forms/Views/CatalogPage.xaml.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 
 using Xamarin.Forms;
@@ -78,7 +77,7 @@ namespace Jammit.Forms.Views
       {
         // Make sure Downloads directory exists.
         var downloadsDir = System.IO.Directory.CreateDirectory(System.IO.Path.Combine(App.DataDirectory, "Downloads"));
-        var zipPath = System.IO.Path.Combine(downloadsDir.FullName, selectedSong.Id.ToString().ToUpper() + ".zip");
+        var zipPath = System.IO.Path.Combine(downloadsDir.FullName, selectedSong.Sku + ".zip");
 
         await App.Client.DownloadSong(selectedSong, zipPath);
         var downloadedStream = System.IO.File.OpenRead(zipPath);
@@ -91,9 +90,12 @@ namespace Jammit.Forms.Views
 
         DownloadProgressBar.Progress = 0;
       }
-      catch (Exception ex)
+      catch (Exception)
       {
-        await DisplayAlert(Localized.CatalogPage_DownloadButtonClicked_CatchTitle, string.Format(Localized.CatalogPage_DownloadButtonClicked_CatchMessage, selectedSong.Id), "OK");
+        await DisplayAlert(
+          Localized.CatalogPage_DownloadButtonClicked_CatchTitle,
+          string.Format(Localized.CatalogPage_DownloadButtonClicked_CatchMessage, selectedSong.Sku),
+          "OK");
       }
     }
 

--- a/Forms/Views/CatalogPage.xaml.cs
+++ b/Forms/Views/CatalogPage.xaml.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -73,12 +73,11 @@ namespace Jammit.Forms.Views
 
       // Download song
       var selectedSong = CatalogView.SelectedItem as SongInfo;
+      // Make sure Downloads directory exists.
+      var downloadsDir = System.IO.Directory.CreateDirectory(System.IO.Path.Combine(App.DataDirectory, "Downloads"));
+      var zipPath = System.IO.Path.Combine(downloadsDir.FullName, selectedSong.Sku + ".zip");
       try
       {
-        // Make sure Downloads directory exists.
-        var downloadsDir = System.IO.Directory.CreateDirectory(System.IO.Path.Combine(App.DataDirectory, "Downloads"));
-        var zipPath = System.IO.Path.Combine(downloadsDir.FullName, selectedSong.Sku + ".zip");
-
         await App.Client.DownloadSong(selectedSong, zipPath);
         var downloadedStream = System.IO.File.OpenRead(zipPath);
         var song = App.Library.AddSong(downloadedStream);
@@ -96,6 +95,9 @@ namespace Jammit.Forms.Views
           Localized.CatalogPage_DownloadButtonClicked_CatchTitle,
           string.Format(Localized.CatalogPage_DownloadButtonClicked_CatchMessage, selectedSong.Sku),
           "OK");
+
+        if (System.IO.File.Exists(zipPath))
+          System.IO.File.Delete(zipPath);
       }
     }
 

--- a/Forms/Views/MenuPage.xaml.cs
+++ b/Forms/Views/MenuPage.xaml.cs
@@ -1,8 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 using Xamarin.Essentials;
 using Xamarin.Forms;

--- a/Forms/Views/TrackSlider.xaml.cs
+++ b/Forms/Views/TrackSlider.xaml.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 
 using Xamarin.Forms;
@@ -53,8 +53,6 @@ namespace Jammit.Forms.Views
 
       VisualStateManager.GoToState(Root, "Active");
     }
-
-    public event EventHandler SoloEnabled;
 
     #region Bindable properties
 

--- a/NAudio/Audio/NAudioJcfPlayer.cs
+++ b/NAudio/Audio/NAudioJcfPlayer.cs
@@ -26,7 +26,7 @@ namespace Jammit.Audio
       _mixer = new WaveMixerStream32();
       _channels = new Dictionary<TrackInfo, WaveChannel32>(media.InstrumentTracks.Count + 1 + 1);
 
-      var songPath = Path.Combine(tracksPath, $"{media.Song.Id.ToString().ToUpper()}.jcf");
+      var songPath = Path.Combine(tracksPath, $"{media.Song.Sku}.jcf");
       foreach (var track in media.InstrumentTracks)
       {
         var stream = File.OpenRead(Path.Combine(songPath, $"{track.Identifier.ToString().ToUpper()}_jcfx"));
@@ -35,7 +35,6 @@ namespace Jammit.Audio
 
       var backingStream = File.OpenRead(Path.Combine(songPath, $"{media.BackingTrack.Identifier.ToString().ToUpper()}_jcfx"));
       _channels[media.BackingTrack] = new WaveChannel32(new ImaWaveStream(backingStream));
-
       _channels[media.ClickTrack] = new WaveChannel32(new ClickTrackStream(media.Beats, stick));
 
       foreach (var channel in _channels.Values)

--- a/UWP/Audio/FFmpegJcfPlayer.cs
+++ b/UWP/Audio/FFmpegJcfPlayer.cs
@@ -25,7 +25,7 @@ namespace Jammit.Audio
       instance._mediaTimelineController.StateChanged += instance.MediaTimelineController_StateChanged;
       instance._mediaTimelineController.Ended += instance.MediaTimelineController_Ended;
 
-      var mediaPath = $"ms-appdata:///local/Tracks/{media.Song.Id.ToString().ToUpper()}.jcf";
+      var mediaPath = $"ms-appdata:///local/Tracks/{media.Song.Sku}.jcf";
       foreach (var track in media.InstrumentTracks)
       {
         await instance.InitPlayer(track, mediaPath);


### PR DESCRIPTION
Updated APIs:

- Jammit.Model.SongInfo
  - Removes
    - Id

This change allows a non-canonical structure in the JCF archives (any file name, any compressed folder structure as long as all files reside next to `info.plist`).

Extra: Downloads are cleared on download/extract errors.