### PR TITLE
Fix macOS RadioButton behavior

### DIFF
--- a/macOS/Forms/Renderers/MacOSRadioButtonRenderer.cs
+++ b/macOS/Forms/Renderers/MacOSRadioButtonRenderer.cs
@@ -1,0 +1,39 @@
+﻿using System;
+
+using AppKit;
+using Xamarin.Forms;
+using Xamarin.Forms.Platform.MacOS;
+
+//TODO: Remove after release of https://github.com/xamarin/Xamarin.Forms/pull/14139
+[assembly: ExportRenderer(typeof(Xamarin.Forms.RadioButton), typeof(Jammit.Forms.Renderers.MacOSRadioButtonRenderer))]
+namespace Jammit.Forms.Renderers
+{
+  public class MacOSRadioButtonRenderer : RadioButtonRenderer
+  {
+		void HandleActivated(object sender, EventArgs args)
+		{
+			if (Element == null || sender == null)
+			{
+				return;
+			}
+
+			Element.IsChecked = (sender as NSButton).State == NSCellStateValue.On;
+		}
+
+    protected override void Dispose(bool disposing)
+    {
+			if (Control != null)
+				Control.Activated -= HandleActivated;
+
+			base.Dispose(disposing);
+    }
+
+    protected override void OnElementChanged(ElementChangedEventArgs<RadioButton> e)
+    {
+      base.OnElementChanged(e);
+
+			if (Control != null)
+				Control.Activated += HandleActivated;
+    }
+  }
+}

--- a/macOS/Unjammit.macOS.csproj
+++ b/macOS/Unjammit.macOS.csproj
@@ -106,6 +106,7 @@
     <Compile Include="Forms\Renderers\MacOSVerticalSliderRenderer.cs" />
     <Compile Include="Forms\Renderers\MacOSDisabledScrollViewRenderer.cs" />
     <Compile Include="Forms\MacOSLocaleSwitcher.cs" />
+    <Compile Include="Forms\Renderers\MacOSRadioButtonRenderer.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Core\Unjammit.Core.csproj">


### PR DESCRIPTION
Implements https://github.com/xamarin/Xamarin.Forms/pull/14139.

RadioButtons get correctly selected exclusively within a group.

TODO: Revert once Xamarin.Forms/pull/14139 is released.