### PR TITLE
Implement empty/stubbed NAudio player

### DIFF
--- a/Gtk/Program.cs
+++ b/Gtk/Program.cs
@@ -68,12 +68,13 @@ namespace Jammit.Gtk
         // LibVLCSharp expects libVLC 4.
         // TODO: Ship with LibVLC 4 nightly build binaries: https://nightlies.videolan.org/
         // TODO: Write a GitHub issue!
-        global::LibVLCSharp.Shared.Core.Initialize();
+        // UWP: Don't even try. This crashes the process irrevocably.
+        if (Xamarin.Essentials.DeviceInfo.Platform != Xamarin.Essentials.DevicePlatform.Unknown)
+          global::LibVLCSharp.Shared.Core.Initialize();
       }
       finally
       {
         global::Gtk.Application.Run();
-
       }
     }
   }

--- a/Gtk/Unjammit.Gtk.csproj
+++ b/Gtk/Unjammit.Gtk.csproj
@@ -72,6 +72,10 @@
       <Project>{c1e423f3-95c1-4807-8db8-6d07979623c7}</Project>
       <Name>Unjammit.Vlc</Name>
     </ProjectReference>
+    <ProjectReference Include="..\NAudio\Unjammit.NAudio.csproj">
+      <Project>{8E64E741-B2BB-443D-89A3-BEC67891BB93}</Project>
+      <Name>Unjammit.NAudio</Name>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Xamarin.Forms.Platform.GTK">
@@ -79,6 +83,9 @@
     </PackageReference>
     <PackageReference Include="LibVLCSharp.Forms.GTK">
       <Version>3.5.0</Version>
+    </PackageReference>
+    <PackageReference Include="NAudio.Core">
+      <Version>2.0.0</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup />

--- a/NAudio/Audio/StubWavePlayer.cs
+++ b/NAudio/Audio/StubWavePlayer.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using NAudio.Wave;
+
+namespace Jammit.Audio
+{
+  public class StubWavePlayer : IWavePlayer
+  {
+    public StubWavePlayer() { }
+
+    #region IWavePlayer
+
+    public float Volume { get; set; }
+
+    public PlaybackState PlaybackState { get; set; } = PlaybackState.Stopped;
+
+    public event EventHandler<StoppedEventArgs> PlaybackStopped;
+
+    public void Dispose() { }
+
+    public void Init(IWaveProvider waveProvider) { }
+
+    public void Pause()
+    {
+      PlaybackState = PlaybackState.Paused;
+    }
+
+    public void Play()
+    {
+      PlaybackState = PlaybackState.Playing;
+    }
+
+    public void Stop()
+    {
+      PlaybackState = PlaybackState.Stopped;
+    }
+
+    #endregion IWavePlayer
+  }
+}


### PR DESCRIPTION
- Define `Jammit.NAudio.StubWavePlayer`
- Allow Gtk app to fall back to StubWavePlayer when LibVLC fails to load.