### PR TITLE
Fix binding event warnings

### DIFF
--- a/Forms/Converters/DigitalTimeConverter.cs
+++ b/Forms/Converters/DigitalTimeConverter.cs
@@ -2,16 +2,33 @@
 
 namespace Jammit.Forms.Converters
 {
-  public class DigitalTimeConverter : Xamarin.Forms.IValueConverter
+  public class DoubleToTimeStampConverter : Xamarin.Forms.IValueConverter
   {
+    #region IValueConverter
+
     public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
     {
-      return TimeSpan.FromSeconds((double)value).ToString(@"mm\:ss");
+        return TimeSpan.FromSeconds((double)value).ToString(@"mm\:ss");
     }
 
     public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
     {
-      return (double)TimeSpan.Parse((string)value).Seconds;
+      throw new NotImplementedException();
+    }
+
+    #endregion IValueConverter
+  }
+
+  public class DoubleToTimeStampBackConverter : Xamarin.Forms.IValueConverter
+  {
+    public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+    {
+      return value;
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+    {
+      return TimeSpan.FromSeconds((double)value);
     }
   }
 }

--- a/Forms/Views/LibraryPage.xaml
+++ b/Forms/Views/LibraryPage.xaml
@@ -9,9 +9,7 @@
     <SearchBar Placeholder="{xaml:TranslateText SongSearch_Placeholder}" TextChanged="SearchBar_TextChanged" />
     <ListView
       x:Name="LibraryView"
-      ItemTapped="LibraryView_ItemTapped"
-      BindingContext="{Static local:App.Library}"
-      ItemsSource="{Binding Songs}">
+      ItemTapped="LibraryView_ItemTapped">
       <ListView.Header>
         <Grid>
           <Label Grid.Column="0" FontAttributes="Bold" Text="{xaml:TranslateText SongInfo_Artist}" />

--- a/Forms/Views/LibraryPage.xaml.cs
+++ b/Forms/Views/LibraryPage.xaml.cs
@@ -13,6 +13,17 @@ namespace Jammit.Forms.Views
       InitializeComponent();
     }
 
+    #region Page
+
+    protected override void OnAppearing()
+    {
+      LibraryView.ItemsSource = App.Library.Songs;
+
+      base.OnAppearing();
+    }
+
+    #endregion Page
+
     private async void LibraryView_ItemTapped(object sender, ItemTappedEventArgs e)
     {
       await Navigation.PushModalAsync(await SongPage.CreateAsync(e.Item as SongInfo));

--- a/Forms/Views/SongPage.xaml
+++ b/Forms/Views/SongPage.xaml
@@ -17,7 +17,8 @@
 
   <ContentPage.Resources>
     <ResourceDictionary>
-      <converters:DigitalTimeConverter x:Key="floatToTimeSpan" />
+      <converters:DoubleToTimeStampConverter x:Key="doubleToTime" />
+      <converters:DoubleToTimeStampBackConverter x:Key="doubleToTimeBack" />
       <Style x:Key="ProgressStyle" TargetType="Label">
         <Setter Property="FontFamily" Value="{OnPlatform UWP=Consolas, iOS=Courier, macOS=Courier}" />
       </Style>
@@ -88,14 +89,17 @@
                BorderColor="Green"
                BackgroundColor="Transparent"
                RelativeLayout.WidthConstraint="{ConstraintExpression Type=RelativeToParent, Property=WidthRequest, Constant=-20}"
-               RelativeLayout.XConstraint="{ConstraintExpression Type=RelativeToParent, Property=Width, Factor=0.5, Constant={StaticResource Key=ScoreCursorOffset}}">
+               RelativeLayout.XConstraint=
+                 "{ConstraintExpression Type=RelativeToParent, Property=Width, Factor=0.5,
+                   Constant={StaticResource Key=ScoreCursorOffset}}">
           </Frame>
 
           <Frame x:Name="CursorBar"
                BorderColor="Green"
                BackgroundColor="Green"
                RelativeLayout.WidthConstraint="{ConstraintExpression Type=Constant, Constant=2}"
-               RelativeLayout.XConstraint="{ConstraintExpression Type=RelativeToView, ElementName=CursorFrame, Property=X, Constant=0}"
+               RelativeLayout.XConstraint=
+                 "{ConstraintExpression Type=RelativeToView, ElementName=CursorFrame, Property=X, Constant=0}"
                />
         </RelativeLayout>
       </ScrollView>
@@ -148,7 +152,7 @@
       <StackLayout x:Name="ProgressLayout"
                    HorizontalOptions="FillAndExpand">
         <FlexLayout VerticalOptions="Start" AlignItems="Center" HeightRequest="36">
-          <Label Text="{Binding Source={x:Reference PositionSlider}, Path=Value, Converter={StaticResource floatToTimeSpan}}"
+          <Label Text="{Binding Source={x:Reference PositionSlider}, Path=Value, Converter={StaticResource doubleToTime}}"
                  BackgroundColor="LightGray"
                  HorizontalOptions="Start"
                  Style="{StaticResource Key=ProgressStyle}"
@@ -158,12 +162,12 @@
                   MaximumTrackColor="LightCyan"
                   Minimum="0"
                   Maximum="{Binding Player.Length.TotalSeconds}"
-                  Value="{Binding Player.Position, Mode=TwoWay}"
+                  Value="{Binding Player.Position, Mode=TwoWay, Converter={StaticResource doubleToTimeBack}}"
                   ValueChanged="PositionSlider_ValueChanged"
                   FlexLayout.Grow="1"
                   Margin="6,0,6,0"
                   />
-          <Label Text="{Binding Source={x:Reference PositionSlider}, Path=Maximum, Converter={StaticResource floatToTimeSpan}}"
+          <Label Text="{Binding Source={x:Reference PositionSlider}, Path=Maximum, Converter={StaticResource doubleToTime}}"
                  BackgroundColor="LightGray"
                  HorizontalOptions="End"
                  Style="{StaticResource Key=ProgressStyle}"

--- a/Forms/Views/TrackSlider.xaml
+++ b/Forms/Views/TrackSlider.xaml
@@ -48,7 +48,6 @@
       <local:VerticalSlider x:Name="VolumeSlider"
               Minimum="0"
               Maximum="100"
-              Value="{Binding Volume, Mode=OneWayToSource}"
               ValueChanged="VolumeSlider_ValueChanged"
               MinimumTrackColor="DarkCyan"
               MaximumTrackColor="LightCyan"


### PR DESCRIPTION
Removes warnings from:

- Unused bindings (currently updating those fields manually)
- Missing back converter from `double` to `TimeSpan`.