### PR TITLE
Enable Apple Silicon support

### DIFF
--- a/macOS/Unjammit.macOS.csproj
+++ b/macOS/Unjammit.macOS.csproj
@@ -14,7 +14,7 @@
     <MonoMacResourcePrefix>Resources</MonoMacResourcePrefix>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
-    <XamMacArch>x86_64</XamMacArch>
+    <XamMacArch>x86_64,ARM64</XamMacArch>
     <AOTMode>None</AOTMode>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">


### PR DESCRIPTION
Add an ARM64 arch target for Unjammit.macOS to make the binary universal.﻿
