### PR TITLE
Fix Windows Publish building

### DIFF
--- a/Scripts/DevOps/Publish.yml
+++ b/Scripts/DevOps/Publish.yml
@@ -194,6 +194,7 @@ stages:
       - job:
         displayName: Windows
         dependsOn: SetUp
+        condition: false
 
         variables:
           - group: Build - Windows

--- a/Scripts/DevOps/Publish.yml
+++ b/Scripts/DevOps/Publish.yml
@@ -71,6 +71,7 @@ stages:
       - job:
         displayName: macOS
         dependsOn: SetUp
+        condition: false
 
         variables:
           - group: Build - Apple
@@ -120,6 +121,7 @@ stages:
       - job:
         displayName: iOS
         dependsOn: SetUp
+        condition: false
 
         variables:
           - group: Build - Apple
@@ -158,6 +160,7 @@ stages:
       - job:
         displayName: Android
         dependsOn: SetUp
+        condition: false
 
         variables:
           - group: Build - Android
@@ -219,6 +222,7 @@ stages:
               publishLocation: Container
 
   - stage: Deploy
+    condition: false #TODO: Remove
     dependsOn:
       - Publish
 

--- a/Scripts/DevOps/Publish.yml
+++ b/Scripts/DevOps/Publish.yml
@@ -194,7 +194,6 @@ stages:
       - job:
         displayName: Windows
         dependsOn: SetUp
-        condition: false
 
         variables:
           - group: Build - Windows
@@ -220,7 +219,6 @@ stages:
               publishLocation: Container
 
   - stage: Deploy
-    condition: false
     dependsOn:
       - Publish
 

--- a/Scripts/DevOps/Publish.yml
+++ b/Scripts/DevOps/Publish.yml
@@ -71,7 +71,6 @@ stages:
       - job:
         displayName: macOS
         dependsOn: SetUp
-        condition: false
 
         variables:
           - group: Build - Apple
@@ -121,7 +120,6 @@ stages:
       - job:
         displayName: iOS
         dependsOn: SetUp
-        condition: false
 
         variables:
           - group: Build - Apple
@@ -160,7 +158,6 @@ stages:
       - job:
         displayName: Android
         dependsOn: SetUp
-        condition: false
 
         variables:
           - group: Build - Android
@@ -222,7 +219,7 @@ stages:
               publishLocation: Container
 
   - stage: Deploy
-    condition: false #TODO: Remove
+    condition: false
     dependsOn:
       - Publish
 

--- a/Scripts/DevOps/Templates/MSBuildSteps.yml
+++ b/Scripts/DevOps/Templates/MSBuildSteps.yml
@@ -36,6 +36,8 @@ steps:
     inputs:
       solution: ${{ parameters.project }}
       msbuildArchitecture: $(MSBuild.MSBuildArchitecture)
+      platform: $(BuildPlatform)
+      configuration: $(BuildConfiguration)
       msbuildArguments: /t:Restore
 
   - task: MSBuild@1
@@ -43,8 +45,8 @@ steps:
     inputs:
       solution: ${{ parameters.project }}
       msbuildArchitecture: $(MSBuild.MSBuildArchitecture)
-      configuration: $(BuildConfiguration)
       platform: $(BuildPlatform)
+      configuration: $(BuildConfiguration)
       msbuildArguments: /r ${{ parameters.msbuildArguments }}
       clean: true
       maximumCpuCount: $(MSBuild.MaximumCpuCount)

--- a/Scripts/DevOps/Templates/MSBuildSteps.yml
+++ b/Scripts/DevOps/Templates/MSBuildSteps.yml
@@ -47,6 +47,6 @@ steps:
       msbuildArchitecture: $(MSBuild.MSBuildArchitecture)
       platform: $(BuildPlatform)
       configuration: $(BuildConfiguration)
-      msbuildArguments: /r ${{ parameters.msbuildArguments }}
+      msbuildArguments: ${{ parameters.msbuildArguments }}
       clean: true
       maximumCpuCount: $(MSBuild.MaximumCpuCount)

--- a/Scripts/DevOps/Templates/PublishWindowsSteps.yml
+++ b/Scripts/DevOps/Templates/PublishWindowsSteps.yml
@@ -33,6 +33,42 @@ steps:
     inputs:
       secureFile: com.unjammit.publisher.p12
 
+  - task: MSBuild@1
+    displayName: Restore Packages (x64)
+    inputs:
+      solution: $(Build.SourcesDirectory)/UWP/Unjammit.UWP.csproj
+      msbuildArchitecture: $(MSBuild.MSBuildArchitecture)
+      platform: x64
+      configuration: $(BuildConfiguration)
+      msbuildArguments: /t:Restore
+
+  - task: MSBuild@1
+    displayName: Restore Packages (x86)
+    inputs:
+      solution: $(Build.SourcesDirectory)/UWP/Unjammit.UWP.csproj
+      msbuildArchitecture: $(MSBuild.MSBuildArchitecture)
+      platform: x86
+      configuration: $(BuildConfiguration)
+      msbuildArguments: /t:Restore
+
+  - task: MSBuild@1
+    displayName: Restore Packages (ARM)
+    inputs:
+      solution: $(Build.SourcesDirectory)/UWP/Unjammit.UWP.csproj
+      msbuildArchitecture: $(MSBuild.MSBuildArchitecture)
+      platform: ARM
+      configuration: $(BuildConfiguration)
+      msbuildArguments: /t:Restore
+
+  - task: MSBuild@1
+    displayName: Restore Packages (ARM64)
+    inputs:
+      solution: $(Build.SourcesDirectory)/UWP/Unjammit.UWP.csproj
+      msbuildArchitecture: $(MSBuild.MSBuildArchitecture)
+      platform: ARM64
+      configuration: $(BuildConfiguration)
+      msbuildArguments: /t:Restore
+
   - template: MSBuildSteps.yml
     parameters:
       project: $(Build.SourcesDirectory)/UWP/Unjammit.UWP.csproj


### PR DESCRIPTION
The corrected per-platform/configuration restore metadata locations made the multi-arch UWP Release (publish) build fail due to missing assets for non-x64 archs.

This PR makes explicit `Restore` MSBuild calls for each arch (platform).