### PR TITLE
Upgrade UWP TargetPlatformVersion to 10.0.22621.0

### DIFF
--- a/UWP/Unjammit.UWP.csproj
+++ b/UWP/Unjammit.UWP.csproj
@@ -11,7 +11,7 @@
     <AssemblyName>Unjammit.UWP</AssemblyName>
     <DefaultLanguage>en</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
-    <TargetPlatformVersion>10.0.22000.0</TargetPlatformVersion>
+    <TargetPlatformVersion>10.0.22621.0</TargetPlatformVersion>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <EnableDotNetNativeCompatibleProfile>true</EnableDotNetNativeCompatibleProfile>


### PR DESCRIPTION
Bumps the development Windows SDK version to match the default (mandatory) installed on the latest Visual Studio 2022 (`17.10.5`).