### PR TITLE
Implement ClickTrackStream.BeatChanged event

### DIFF
--- a/Android/Audio/AndroidMediaJcfPlayer.cs
+++ b/Android/Audio/AndroidMediaJcfPlayer.cs
@@ -26,8 +26,6 @@ namespace Jammit.Audio
 
     public event EventHandler PositionChanged;
 
-    public event EventHandler CountdownFinished;
-
     public void Play()
     {
       _player.Start();
@@ -54,6 +52,21 @@ namespace Jammit.Audio
     public void SetVolume(PlayableTrackInfo track, uint volume)
     {
       _player.SetVolume((float)volume, (float)volume);
+    }
+
+    TrackState.AudioStatus IJcfPlayer.GetAudioStatus(PlayableTrackInfo track)
+    {
+      throw new NotImplementedException();
+    }
+
+    void IJcfPlayer.Mute(PlayableTrackInfo track)
+    {
+      throw new NotImplementedException();
+    }
+
+    void IJcfPlayer.Unmute(PlayableTrackInfo track)
+    {
+      throw new NotImplementedException();
     }
 
     public TimeSpan Position

--- a/Apple/Audio/AppleJcfPlayer.cs
+++ b/Apple/Audio/AppleJcfPlayer.cs
@@ -44,8 +44,6 @@ namespace Jammit.Audio
 
     public event EventHandler PositionChanged;
 
-    public event EventHandler CountdownFinished;
-
     public void Play()
     {
       if (PlaybackStatus.Playing == State)

--- a/Apple/Audio/AppleJcfPlayer.cs
+++ b/Apple/Audio/AppleJcfPlayer.cs
@@ -98,6 +98,21 @@ namespace Jammit.Audio
       players[track].Volume = volume / 100.0f;
     }
 
+    TrackState.AudioStatus IJcfPlayer.GetAudioStatus(PlayableTrackInfo track)
+    {
+      throw new NotImplementedException();
+    }
+
+    void IJcfPlayer.Mute(PlayableTrackInfo track)
+    {
+      throw new NotImplementedException();
+    }
+
+    void IJcfPlayer.Unmute(PlayableTrackInfo track)
+    {
+      throw new NotImplementedException();
+    }
+
     public uint TotalBeats { get; private set; }
 
     public TimeSpan Position

--- a/Core/Audio/IJcfPlayer.cs
+++ b/Core/Audio/IJcfPlayer.cs
@@ -10,9 +10,15 @@ namespace Jammit.Audio
 
     void Stop();
 
+    TrackState.AudioStatus GetAudioStatus(Model.PlayableTrackInfo track);
+
     uint GetVolume(Model.PlayableTrackInfo track);
 
     void SetVolume(Model.PlayableTrackInfo track, uint volume);
+
+    void Mute(Model.PlayableTrackInfo track);
+
+    void Unmute(Model.PlayableTrackInfo track);
 
     uint TotalBeats { get; }
 

--- a/Core/Audio/IJcfPlayer.cs
+++ b/Core/Audio/IJcfPlayer.cs
@@ -31,7 +31,5 @@ namespace Jammit.Audio
     uint Countdown { get; set; }
 
     event EventHandler PositionChanged;
-
-    event EventHandler CountdownFinished;
   }
 }

--- a/Core/Audio/TrackState.cs
+++ b/Core/Audio/TrackState.cs
@@ -1,0 +1,20 @@
+﻿using System;
+
+namespace Jammit.Audio
+{
+  public class TrackState
+  {
+    public enum AudioStatus
+    {
+      On,
+      Muted,      // Black-listed off
+      Solo,       // White-listed on
+      Excluded,   // Muted by exclusion of Solo white list
+      AutoMuted   // i.e. click track countdown
+    }
+
+    public AudioStatus Status = AudioStatus.On;
+
+    public uint Volume = 100;
+  }
+}

--- a/Forms/Views/SongPage.xaml
+++ b/Forms/Views/SongPage.xaml
@@ -188,6 +188,7 @@
                   Value="{Binding Player.Countdown}"
                   FlexLayout.Grow="1"
                   Margin="6,0,6,0"
+                  IsEnabled="{OnPlatform Default=true, UWP=false}"
                   />
           <Label Text="{Binding Player.TotalBeats, StringFormat='{}{0,5:F0}'}"
                  BackgroundColor="LightGray"

--- a/Forms/Views/SongPage.xaml.cs
+++ b/Forms/Views/SongPage.xaml.cs
@@ -306,9 +306,6 @@ namespace Jammit.Forms.Views
       }
       else
       {
-        if (Audio.PlaybackStatus.Stopped == Player.State)
-          Player.SetVolume(Media.ClickTrack, Settings.Get(Settings.TrackVolumeKey(Media.ClickTrack), 0));
-
         Player.Play();
 
         Device.StartTimer(TimeSpan.FromMilliseconds(30), () =>

--- a/Forms/Views/TrackSlider.xaml.cs
+++ b/Forms/Views/TrackSlider.xaml.cs
@@ -29,7 +29,7 @@ namespace Jammit.Forms.Views
 
     void Mute()
     {
-      Player.SetVolume(Track, 0);
+      Player.Mute(Track);
       _state = State.Muted;
 
       SetSoundState("Muted", false);
@@ -37,7 +37,7 @@ namespace Jammit.Forms.Views
 
     void Unmute()
     {
-      Player.SetVolume(Track, (uint)Volume);
+      Player.Unmute(Track);
       _state = State.Normal;
 
       SetSoundState("Active", true);

--- a/NAudio/Audio/ClickTrackStream.cs
+++ b/NAudio/Audio/ClickTrackStream.cs
@@ -51,7 +51,16 @@ namespace Jammit.Audio
         for (var i = 0; i < _beats.Count; i++)
         {
           _currentBeat = i;
-          if (_beats[i].Time >= time) break;
+
+          var beatChangedArgs = new BeatChangedEventArgs
+          {
+            CurrentBeatIndex = (uint)_currentBeat,
+            CurrentBeat = _beats[_currentBeat]
+          };
+          OnBeatChanged?.Invoke(this, beatChangedArgs);
+
+          if (_beats[i].Time >= time)
+            break;
         }
       }
     }
@@ -63,12 +72,6 @@ namespace Jammit.Audio
       int bytesRead = 0;
       while (count > 0 && _beats.Count > _currentBeat)
       {
-        if (_player != null && _currentBeat > _player.Countdown && _player.Countdown != 0)
-        {
-          _countdownFinished?.Invoke(this, new EventArgs());
-          return 0;
-        }
-
         var sampleOffset = _samplePos - (int)((_beats[_currentBeat].Time - 0.005) * 44100);
         // empty space before click
         while (sampleOffset < 0 && count > 0)
@@ -96,9 +99,25 @@ namespace Jammit.Audio
         if (sampleOffset >= _click.Length)
         {
           _currentBeat++;
+
+          var beatChangedArgs = new BeatChangedEventArgs
+          {
+            CurrentBeatIndex = (uint)_currentBeat,
+            CurrentBeat = _beats[_currentBeat]
+          };
+          OnBeatChanged?.Invoke(this, beatChangedArgs);
         }
       }
       return bytesRead;
+    }
+
+    public event EventHandler<BeatChangedEventArgs> OnBeatChanged;
+
+    //TODO: Move?
+    public class BeatChangedEventArgs : EventArgs
+    {
+      public uint CurrentBeatIndex;
+      public Model.Beat CurrentBeat;
     }
   }
 }

--- a/NAudio/Audio/ClickTrackStream.cs
+++ b/NAudio/Audio/ClickTrackStream.cs
@@ -10,10 +10,6 @@ namespace Jammit.Audio
 
     private readonly short[] _click;
 
-    private EventHandler _countdownFinished;
-
-    private IJcfPlayer _player;
-
     //var stick = Properties.Resources.stick;
     public ClickTrackStream(IReadOnlyList<Model.Beat> beats, byte[] stick)
     {
@@ -22,12 +18,6 @@ namespace Jammit.Audio
       Length = (long)(_beats[_beats.Count - 1].Time*44100*4);
       _click = new short[stick.Length/2];
       Buffer.BlockCopy(stick, 0, _click, 0, stick.Length);
-    }
-    public ClickTrackStream(IReadOnlyList<Model.Beat> beats, byte[] stick, EventHandler countdownFinished)
-      : this(beats, stick)
-    {
-      _countdownFinished = countdownFinished;
-      _player = _countdownFinished.Target as IJcfPlayer;
     }
 
     public override long Length { get; }

--- a/NAudio/Audio/ClickTrackStream.cs
+++ b/NAudio/Audio/ClickTrackStream.cs
@@ -47,7 +47,7 @@ namespace Jammit.Audio
             CurrentBeatIndex = (uint)_currentBeat,
             CurrentBeat = _beats[_currentBeat]
           };
-          OnBeatChanged?.Invoke(this, beatChangedArgs);
+          BeatChanged?.Invoke(this, beatChangedArgs);
 
           if (_beats[i].Time >= time)
             break;
@@ -95,13 +95,13 @@ namespace Jammit.Audio
             CurrentBeatIndex = (uint)_currentBeat,
             CurrentBeat = _beats[_currentBeat]
           };
-          OnBeatChanged?.Invoke(this, beatChangedArgs);
+          BeatChanged?.Invoke(this, beatChangedArgs);
         }
       }
       return bytesRead;
     }
 
-    public event EventHandler<BeatChangedEventArgs> OnBeatChanged;
+    public event EventHandler<BeatChangedEventArgs> BeatChanged;
 
     //TODO: Move?
     public class BeatChangedEventArgs : EventArgs

--- a/NAudio/Audio/NAudioJcfPlayer.cs
+++ b/NAudio/Audio/NAudioJcfPlayer.cs
@@ -29,8 +29,6 @@ namespace Jammit.Audio
       _channels = new Dictionary<TrackInfo, WaveChannel32>(media.InstrumentTracks.Count + 1 + 1);
       _trackStates = new Dictionary<TrackInfo, TrackState>(media.InstrumentTracks.Count + 1 + 1);
 
-      CountdownFinished += NotifyCountdownFinished;
-
       var songPath = Path.Combine(tracksPath, $"{media.Song.Sku}.jcf");
       foreach (var track in media.InstrumentTracks)
       {
@@ -43,7 +41,7 @@ namespace Jammit.Audio
       _channels[media.BackingTrack] = new WaveChannel32(new ImaWaveStream(backingStream));
       _trackStates[media.BackingTrack] = new TrackState();
 
-      _clickTrackStream = new ClickTrackStream(media.Beats, stick, CountdownFinished);
+      _clickTrackStream = new ClickTrackStream(media.Beats, stick);
       _clickTrackStream.OnBeatChanged += NotifyBeatChanged;
       _channels[media.ClickTrack] = new WaveChannel32(_clickTrackStream);
       _trackStates[media.ClickTrack] = new TrackState();
@@ -64,8 +62,6 @@ namespace Jammit.Audio
 
     ~NAudioJcfPlayer()
     {
-      CountdownFinished -= NotifyCountdownFinished;
-
       _clickTrackStream.OnBeatChanged -= NotifyBeatChanged;
 
       if (PlaybackState.Playing == _waveOut.PlaybackState)
@@ -77,8 +73,6 @@ namespace Jammit.Audio
     #region IJcfPlayer members
 
     public event EventHandler PositionChanged;
-
-    public event EventHandler CountdownFinished;
 
     public void Play()
     {
@@ -176,12 +170,6 @@ namespace Jammit.Audio
     public void NotifyPositionChanged()
     {
       PositionChanged?.Invoke(this, new EventArgs());
-    }
-
-    private void NotifyCountdownFinished(object sender, EventArgs e)
-    {
-      //SetVolume(_media.ClickTrack, 0);
-      Mute(_media.ClickTrack);
     }
 
     private void NotifyBeatChanged(object sender, ClickTrackStream.BeatChangedEventArgs args)

--- a/NAudio/Audio/NAudioJcfPlayer.cs
+++ b/NAudio/Audio/NAudioJcfPlayer.cs
@@ -42,7 +42,7 @@ namespace Jammit.Audio
       _trackStates[media.BackingTrack] = new TrackState();
 
       _clickTrackStream = new ClickTrackStream(media.Beats, stick);
-      _clickTrackStream.OnBeatChanged += NotifyBeatChanged;
+      _clickTrackStream.BeatChanged += NotifyBeatChanged;
       _channels[media.ClickTrack] = new WaveChannel32(_clickTrackStream);
       _trackStates[media.ClickTrack] = new TrackState();
 
@@ -62,7 +62,7 @@ namespace Jammit.Audio
 
     ~NAudioJcfPlayer()
     {
-      _clickTrackStream.OnBeatChanged -= NotifyBeatChanged;
+      _clickTrackStream.BeatChanged -= NotifyBeatChanged;
 
       if (PlaybackState.Playing == _waveOut.PlaybackState)
         _waveOut.Stop();

--- a/NAudio/Audio/NAudioJcfPlayer.cs
+++ b/NAudio/Audio/NAudioJcfPlayer.cs
@@ -102,10 +102,6 @@ namespace Jammit.Audio
 
     public void SetVolume(PlayableTrackInfo track, uint volume)
     {
-      //_channels[track].Volume = volume / 100.0f;
-      ////TODO: Add ClickTrackStream "volume"?
-      ///
-
       _trackStates[track].Volume = volume;
 
       var trackAudioStatus = _trackStates[track].Status;

--- a/UWP/Audio/FFmpegJcfPlayer.cs
+++ b/UWP/Audio/FFmpegJcfPlayer.cs
@@ -34,6 +34,8 @@ namespace Jammit.Audio
 
       instance.Length = media.Length;
 
+      instance.TotalBeats = (uint)media.Beats.Count;
+
       return instance;
     }
 

--- a/UWP/Audio/FFmpegJcfPlayer.cs
+++ b/UWP/Audio/FFmpegJcfPlayer.cs
@@ -104,8 +104,6 @@ namespace Jammit.Audio
 
     public event EventHandler PositionChanged;
 
-    public event EventHandler CountdownFinished;
-
     public void Play()
     {
       if (PlaybackStatus.Playing == State)

--- a/UWP/Audio/FFmpegJcfPlayer.cs
+++ b/UWP/Audio/FFmpegJcfPlayer.cs
@@ -147,6 +147,21 @@ namespace Jammit.Audio
       _players[track].Player.Volume = volume / 100.0;
     }
 
+    TrackState.AudioStatus IJcfPlayer.GetAudioStatus(PlayableTrackInfo track)
+    {
+      throw new NotImplementedException();
+    }
+
+    void IJcfPlayer.Mute(PlayableTrackInfo track)
+    {
+      throw new NotImplementedException();
+    }
+
+    void IJcfPlayer.Unmute(PlayableTrackInfo track)
+    {
+      throw new NotImplementedException();
+    }
+
     public TimeSpan Position
     {
       get

--- a/UWP/Audio/FFmpegJcfPlayer.cs
+++ b/UWP/Audio/FFmpegJcfPlayer.cs
@@ -19,6 +19,7 @@ namespace Jammit.Audio
       var instance = new FFmpegJcfPlayer();
 
       // Capacity => instruments + backing (TODO: + click)
+      instance._trackStates = new Dictionary<PlayableTrackInfo, TrackState>(media.InstrumentTracks.Count + 1);
       instance._players = new Dictionary<PlayableTrackInfo, (MediaPlayer Player, FFmpegInterop.FFmpegInteropMSS)>(media.InstrumentTracks.Count + 1);
       instance._mediaTimelineController = new MediaTimelineController();
       instance._mediaTimelineController.PositionChanged += instance.MediaTimelineController_PositionChanged;
@@ -43,6 +44,7 @@ namespace Jammit.Audio
 
     #region private members
 
+    private IDictionary<PlayableTrackInfo, TrackState> _trackStates;
     private Dictionary<PlayableTrackInfo, (MediaPlayer Player, FFmpegInterop.FFmpegInteropMSS)> _players;
     private MediaTimelineController _mediaTimelineController;
 
@@ -62,6 +64,7 @@ namespace Jammit.Audio
 
       // FFmpegInteropMSS instances hold the stream reference. Their scope must be kept.
       _players[track] = (player, ffmpegSource);
+      _trackStates[track] = new TrackState();
     }
 
     #endregion
@@ -137,7 +140,7 @@ namespace Jammit.Audio
 
     public uint GetVolume(PlayableTrackInfo track)
     {
-      return (uint)_players[track].Player.Volume;
+      return _trackStates[track].Volume;
     }
 
     public void SetVolume(PlayableTrackInfo track, uint volume)
@@ -146,22 +149,33 @@ namespace Jammit.Audio
       if (track.Class == "JMClickTrack")
         return;
 
-      _players[track].Player.Volume = volume / 100.0;
+      _trackStates[track].Volume = volume;
+
+      var trackAudioStatus = _trackStates[track].Status;
+      if (trackAudioStatus != TrackState.AudioStatus.Muted &&
+          trackAudioStatus != TrackState.AudioStatus.AutoMuted &&
+          trackAudioStatus != TrackState.AudioStatus.Excluded)
+        _players[track].Player.Volume = volume / 100.0;
     }
 
     TrackState.AudioStatus IJcfPlayer.GetAudioStatus(PlayableTrackInfo track)
     {
-      throw new NotImplementedException();
+      if (_players[track].Player.Volume > 0)
+        return TrackState.AudioStatus.On;
+      else
+        return TrackState.AudioStatus.Muted;
     }
 
     void IJcfPlayer.Mute(PlayableTrackInfo track)
     {
-      throw new NotImplementedException();
+      _trackStates[track].Status = TrackState.AudioStatus.Muted;
+      _players[track].Player.Volume = 0;
     }
 
     void IJcfPlayer.Unmute(PlayableTrackInfo track)
     {
-      throw new NotImplementedException();
+      _players[track].Player.Volume = _trackStates[track].Volume / 100;
+      _trackStates[track].Status = TrackState.AudioStatus.On;
     }
 
     public TimeSpan Position

--- a/Vlc/Audio/VlcJcfPlayer.cs
+++ b/Vlc/Audio/VlcJcfPlayer.cs
@@ -98,8 +98,6 @@ namespace Jammit.Audio
 
     public event EventHandler PositionChanged;
 
-    public event EventHandler CountdownFinished;
-
     public uint TotalBeats { get; private set; }
 
     public uint Countdown { get; set; } = 0;
@@ -135,6 +133,21 @@ namespace Jammit.Audio
           player.Stop();
 
       Position = TimeSpan.Zero;
+    }
+
+    TrackState.AudioStatus IJcfPlayer.GetAudioStatus(PlayableTrackInfo track)
+    {
+      throw new NotImplementedException();
+    }
+
+    void IJcfPlayer.Mute(PlayableTrackInfo track)
+    {
+      throw new NotImplementedException();
+    }
+
+    void IJcfPlayer.Unmute(PlayableTrackInfo track)
+    {
+      throw new NotImplementedException();
     }
 
     #endregion IJcfPlayer


### PR DESCRIPTION
## Description

Defines an event that triggers exactly when the current beat has been changed in the click track (NAudio only).

Also:
- Exposes track audio status (On, Solo, Muted, AutoMuted...)
- Adds Separate muting/unmuting behavior from plain volume setting:
  - IJcfPlayer.SetVolume idempotently sets the intended volume, while conditionally updating the effective track volume.

## Motivation

Allows for objects owning the low-level click track stream to add any custom behavior (i.e. managing countdown).
