### PR TITLE
Upgrade to FFmpegInteropX 0.0.4

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,7 +4,7 @@ indent_size = 2
 end_of_line = lf
 insert_final_newline = true
 
-[*.{appxmanifest,csproj,props,targets,xaml,xml}]
+[*.{appxmanifest,csproj,nuspec,props,targets,xaml,xml}]
 end_of_line = crlf
 insert_final_newline = false
 

--- a/Scripts/NuGet/Hyvart.FFmpegInteropX.nuspec
+++ b/Scripts/NuGet/Hyvart.FFmpegInteropX.nuspec
@@ -22,13 +22,6 @@ nuget.exe pack -OutputDirectory Output -Properties 'ffmpegInteropXDir=C:\ffmpegI
     <file src="$ffmpegInteropXDir$\Output\FFmpegInteropX\x64\Release\FFmpegInteropX.winmd"  target="lib\uap10.0" />
     <file src="$ffmpegInteropXDir$\Output\FFmpegInteropX\x64\Release\FFmpegInteropX.xml"    target="lib\uap10.0" />
 
-    <file src="$vcpkgDir$\installed\x64-uwp\include\libavcodec\**\*.h"                      target="include\libavcodec" />
-    <file src="$vcpkgDir$\installed\x64-uwp\include\libavfilter\**\*.h"                     target="include\libavfilter" />
-    <file src="$vcpkgDir$\installed\x64-uwp\include\libavformat\**\*.h"                     target="include\libavformat" />
-    <file src="$vcpkgDir$\installed\x64-uwp\include\libavutil\**\*.h"                       target="include\libavutil" />
-    <file src="$vcpkgDir$\installed\x64-uwp\include\libswresample\**\*.h"                   target="include\libswresample" />
-    <!-- TODO:libswscale? -->
-
     <file src="$vcpkgDir$\installed\x64-uwp\bin\avcodec-*"                                  target="runtimes\win10-x64\native" />
     <file src="$vcpkgDir$\installed\x64-uwp\bin\avfilter-*"                                 target="runtimes\win10-x64\native" />
     <file src="$vcpkgDir$\installed\x64-uwp\bin\avformat-*"                                 target="runtimes\win10-x64\native" />

--- a/Scripts/NuGet/Hyvart.FFmpegInteropX.nuspec
+++ b/Scripts/NuGet/Hyvart.FFmpegInteropX.nuspec
@@ -27,12 +27,14 @@ nuget.exe pack -OutputDirectory Output -Properties 'ffmpegInteropXDir=C:\ffmpegI
     <file src="$vcpkgDir$\installed\x64-uwp\include\libavformat\**\*.h"                     target="include\libavformat" />
     <file src="$vcpkgDir$\installed\x64-uwp\include\libavutil\**\*.h"                       target="include\libavutil" />
     <file src="$vcpkgDir$\installed\x64-uwp\include\libswresample\**\*.h"                   target="include\libswresample" />
+    <!-- TODO:libswscale? -->
 
     <file src="$vcpkgDir$\installed\x64-uwp\bin\avcodec-*"                                  target="runtimes\win10-x64\native" />
     <file src="$vcpkgDir$\installed\x64-uwp\bin\avfilter-*"                                 target="runtimes\win10-x64\native" />
     <file src="$vcpkgDir$\installed\x64-uwp\bin\avformat-*"                                 target="runtimes\win10-x64\native" />
     <file src="$vcpkgDir$\installed\x64-uwp\bin\avutil-*"                                   target="runtimes\win10-x64\native" />
     <file src="$vcpkgDir$\installed\x64-uwp\bin\swresample-*"                               target="runtimes\win10-x64\native" />
+    <file src="$vcpkgDir$\installed\x64-uwp\bin\swscale*"                                   target="runtimes\win10-x64\native" />
     <file src="$ffmpegInteropXDir$\Output\FFmpegInteropX\x64\Release\FFmpegInteropX.dll"    target="runtimes\win10-x64\native" />
     <file src="$ffmpegInteropXDir$\Output\FFmpegInteropX\x64\Release\FFmpegInteropX.pdb"    target="runtimes\win10-x64\native" />
 
@@ -41,6 +43,7 @@ nuget.exe pack -OutputDirectory Output -Properties 'ffmpegInteropXDir=C:\ffmpegI
     <file src="$vcpkgDir$\installed\x86-uwp\bin\avformat-*"                                 target="runtimes\win10-x86\native" />
     <file src="$vcpkgDir$\installed\x86-uwp\bin\avutil-*"                                   target="runtimes\win10-x86\native" />
     <file src="$vcpkgDir$\installed\x86-uwp\bin\swresample-*"                               target="runtimes\win10-x86\native" />
+    <file src="$vcpkgDir$\installed\x86-uwp\bin\swscale*"                                   target="runtimes\win10-x86\native" />
     <file src="$ffmpegInteropXDir$\Output\FFmpegInteropX\x86\Release\FFmpegInteropX.dll"    target="runtimes\win10-x86\native" />
     <file src="$ffmpegInteropXDir$\Output\FFmpegInteropX\x86\Release\FFmpegInteropX.pdb"    target="runtimes\win10-x86\native" />
 
@@ -49,6 +52,7 @@ nuget.exe pack -OutputDirectory Output -Properties 'ffmpegInteropXDir=C:\ffmpegI
     <file src="$vcpkgDir$\installed\arm64-uwp\bin\avformat-*"                               target="runtimes\win10-arm64\native" />
     <file src="$vcpkgDir$\installed\arm64-uwp\bin\avutil-*"                                 target="runtimes\win10-arm64\native" />
     <file src="$vcpkgDir$\installed\arm64-uwp\bin\swresample-*"                             target="runtimes\win10-arm64\native" />
+    <file src="$vcpkgDir$\installed\arm64-uwp\bin\swscale*"                                 target="runtimes\win10-arm64\native" />
     <file src="$ffmpegInteropXDir$\Output\FFmpegInteropX\ARM64\Release\FFmpegInteropX.dll"  target="runtimes\win10-arm64\native" />
     <file src="$ffmpegInteropXDir$\Output\FFmpegInteropX\ARM64\Release\FFmpegInteropX.pdb"  target="runtimes\win10-arm64\native" />
 
@@ -57,6 +61,7 @@ nuget.exe pack -OutputDirectory Output -Properties 'ffmpegInteropXDir=C:\ffmpegI
     <file src="$vcpkgDir$\installed\arm-uwp\bin\avformat-*"                                 target="runtimes\win10-arm\native" />
     <file src="$vcpkgDir$\installed\arm-uwp\bin\avutil-*"                                   target="runtimes\win10-arm\native" />
     <file src="$vcpkgDir$\installed\arm-uwp\bin\swresample-*"                               target="runtimes\win10-arm\native" />
+    <file src="$vcpkgDir$\installed\arm-uwp\bin\swscale*"                                   target="runtimes\win10-arm\native" />
     <file src="$ffmpegInteropXDir$\Output\FFmpegInteropX\ARM\Release\FFmpegInteropX.dll"    target="runtimes\win10-arm\native" />
     <file src="$ffmpegInteropXDir$\Output\FFmpegInteropX\ARM\Release\FFmpegInteropX.pdb"    target="runtimes\win10-arm\native" />
   </files>

--- a/Scripts/NuGet/Hyvart.FFmpegInteropX.nuspec
+++ b/Scripts/NuGet/Hyvart.FFmpegInteropX.nuspec
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+Sample usage:
+nuget.exe pack -OutputDirectory Output -Properties 'ffmpegInteropXDir=C:\ffmpegInteropX;vcpkgDir=C:\vcpkg;repositoryUrl=https://github.com/ffmpeginteropx/FFmpegInteropX;repositoryCommit=41e6078c77223d869aabfb713a3106cc282ce7e5'
+-->
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+  <metadata>
+    <id>Hyvart.FFmpegInteropX</id>
+    <version>$version$</version>
+    <description>FFmpeg interoperability component for UWP</description>
+    <authors>FFmpegInteropX</authors>
+    <projectUrl>https://github.com/ffmpeginteropx/FFmpegInteropX</projectUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <license type="expression">LGPL-2.1-or-later AND Zlib AND MIT</license>
+    <dependencies>
+      <group targetFramework="uap10.0" />
+    </dependencies>
+    <repository type="git" url="$repositoryUrl$" commit="$repositoryCommit$" />
+  </metadata>
+  <files>
+    <file src="$ffmpegInteropXDir$\Output\FFmpegInteropX\x64\Release\FFmpegInteropX.winmd"  target="lib\uap10.0" />
+    <file src="$ffmpegInteropXDir$\Output\FFmpegInteropX\x64\Release\FFmpegInteropX.xml"    target="lib\uap10.0" />
+
+    <file src="$vcpkgDir$\installed\x64-uwp\include\libavcodec\**\*.h"                      target="include\libavcodec" />
+    <file src="$vcpkgDir$\installed\x64-uwp\include\libavfilter\**\*.h"                     target="include\libavfilter" />
+    <file src="$vcpkgDir$\installed\x64-uwp\include\libavformat\**\*.h"                     target="include\libavformat" />
+    <file src="$vcpkgDir$\installed\x64-uwp\include\libavutil\**\*.h"                       target="include\libavutil" />
+    <file src="$vcpkgDir$\installed\x64-uwp\include\libswresample\**\*.h"                   target="include\libswresample" />
+
+    <file src="$vcpkgDir$\installed\x64-uwp\bin\avcodec-*"                                  target="runtimes\win10-x64\native" />
+    <file src="$vcpkgDir$\installed\x64-uwp\bin\avfilter-*"                                 target="runtimes\win10-x64\native" />
+    <file src="$vcpkgDir$\installed\x64-uwp\bin\avformat-*"                                 target="runtimes\win10-x64\native" />
+    <file src="$vcpkgDir$\installed\x64-uwp\bin\avutil-*"                                   target="runtimes\win10-x64\native" />
+    <file src="$vcpkgDir$\installed\x64-uwp\bin\swresample-*"                               target="runtimes\win10-x64\native" />
+    <file src="$ffmpegInteropXDir$\Output\FFmpegInteropX\x64\Release\FFmpegInteropX.dll"    target="runtimes\win10-x64\native" />
+    <file src="$ffmpegInteropXDir$\Output\FFmpegInteropX\x64\Release\FFmpegInteropX.pdb"    target="runtimes\win10-x64\native" />
+
+    <file src="$vcpkgDir$\installed\x86-uwp\bin\avcodec-*"                                  target="runtimes\win10-x86\native" />
+    <file src="$vcpkgDir$\installed\x86-uwp\bin\avfilter-*"                                 target="runtimes\win10-x86\native" />
+    <file src="$vcpkgDir$\installed\x86-uwp\bin\avformat-*"                                 target="runtimes\win10-x86\native" />
+    <file src="$vcpkgDir$\installed\x86-uwp\bin\avutil-*"                                   target="runtimes\win10-x86\native" />
+    <file src="$vcpkgDir$\installed\x86-uwp\bin\swresample-*"                               target="runtimes\win10-x86\native" />
+    <file src="$ffmpegInteropXDir$\Output\FFmpegInteropX\x86\Release\FFmpegInteropX.dll"    target="runtimes\win10-x86\native" />
+    <file src="$ffmpegInteropXDir$\Output\FFmpegInteropX\x86\Release\FFmpegInteropX.pdb"    target="runtimes\win10-x86\native" />
+
+    <file src="$vcpkgDir$\installed\arm64-uwp\bin\avcodec-*"                                target="runtimes\win10-arm64\native" />
+    <file src="$vcpkgDir$\installed\arm64-uwp\bin\avfilter-*"                               target="runtimes\win10-arm64\native" />
+    <file src="$vcpkgDir$\installed\arm64-uwp\bin\avformat-*"                               target="runtimes\win10-arm64\native" />
+    <file src="$vcpkgDir$\installed\arm64-uwp\bin\avutil-*"                                 target="runtimes\win10-arm64\native" />
+    <file src="$vcpkgDir$\installed\arm64-uwp\bin\swresample-*"                             target="runtimes\win10-arm64\native" />
+    <file src="$ffmpegInteropXDir$\Output\FFmpegInteropX\ARM64\Release\FFmpegInteropX.dll"  target="runtimes\win10-arm64\native" />
+    <file src="$ffmpegInteropXDir$\Output\FFmpegInteropX\ARM64\Release\FFmpegInteropX.pdb"  target="runtimes\win10-arm64\native" />
+
+    <file src="$vcpkgDir$\installed\arm-uwp\bin\avcodec-*"                                  target="runtimes\win10-arm\native" />
+    <file src="$vcpkgDir$\installed\arm-uwp\bin\avfilter-*"                                 target="runtimes\win10-arm\native" />
+    <file src="$vcpkgDir$\installed\arm-uwp\bin\avformat-*"                                 target="runtimes\win10-arm\native" />
+    <file src="$vcpkgDir$\installed\arm-uwp\bin\avutil-*"                                   target="runtimes\win10-arm\native" />
+    <file src="$vcpkgDir$\installed\arm-uwp\bin\swresample-*"                               target="runtimes\win10-arm\native" />
+    <file src="$ffmpegInteropXDir$\Output\FFmpegInteropX\ARM\Release\FFmpegInteropX.dll"    target="runtimes\win10-arm\native" />
+    <file src="$ffmpegInteropXDir$\Output\FFmpegInteropX\ARM\Release\FFmpegInteropX.pdb"    target="runtimes\win10-arm\native" />
+  </files>
+</package>

--- a/UWP/Audio/FFmpegJcfPlayer.cs
+++ b/UWP/Audio/FFmpegJcfPlayer.cs
@@ -4,7 +4,6 @@ using System.Threading.Tasks;
 
 using Jammit.Model;
 using Windows.Media;
-using Windows.Media.Core;
 using Windows.Media.Playback;
 using Xamarin.Forms;
 

--- a/UWP/Audio/FFmpegJcfPlayer.cs
+++ b/UWP/Audio/FFmpegJcfPlayer.cs
@@ -20,7 +20,7 @@ namespace Jammit.Audio
 
       // Capacity => instruments + backing (TODO: + click)
       instance._trackStates = new Dictionary<PlayableTrackInfo, TrackState>(media.InstrumentTracks.Count + 1);
-      instance._players = new Dictionary<PlayableTrackInfo, (MediaPlayer Player, FFmpegInterop.FFmpegInteropMSS)>(media.InstrumentTracks.Count + 1);
+      instance._players = new Dictionary<PlayableTrackInfo, (MediaPlayer Player, FFmpegInteropX.FFmpegMediaSource)>(media.InstrumentTracks.Count + 1);
       instance._mediaTimelineController = new MediaTimelineController();
       instance._mediaTimelineController.PositionChanged += instance.MediaTimelineController_PositionChanged;
       instance._mediaTimelineController.StateChanged += instance.MediaTimelineController_StateChanged;
@@ -45,7 +45,7 @@ namespace Jammit.Audio
     #region private members
 
     private IDictionary<PlayableTrackInfo, TrackState> _trackStates;
-    private Dictionary<PlayableTrackInfo, (MediaPlayer Player, FFmpegInterop.FFmpegInteropMSS)> _players;
+    private Dictionary<PlayableTrackInfo, (MediaPlayer Player, FFmpegInteropX.FFmpegMediaSource)> _players;
     private MediaTimelineController _mediaTimelineController;
 
     private async Task InitPlayer(PlayableTrackInfo track, string mediaPath)
@@ -53,7 +53,7 @@ namespace Jammit.Audio
       var uri = $"{mediaPath}/{track.Identifier.ToString().ToUpper()}_jcfx";
       var file = await Windows.Storage.StorageFile.GetFileFromApplicationUriAsync(new Uri(uri));
       var stream = await file.OpenReadAsync();
-      var ffmpegSource = await FFmpegInterop.FFmpegInteropMSS.CreateFromStreamAsync(stream);
+      var ffmpegSource = await FFmpegInteropX.FFmpegMediaSource.CreateFromStreamAsync(stream);
       //TODO: Re-enable. Possible bug in FFmpegInterop.
       //var ffmpegSource = await FFmpegInterop.FFmpegInteropMSS.CreateFromUriAsync(uri);
 

--- a/UWP/Unjammit.UWP.csproj
+++ b/UWP/Unjammit.UWP.csproj
@@ -133,7 +133,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Hyvart.FFmpegInteropX">
-      <Version>0.0.3</Version>
+      <Version>0.0.4</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
       <Version>6.2.14</Version>


### PR DESCRIPTION
## Description

- Upgrade to Hyvart.FFmpegInteropX 0.0.4
- Add FFmpegInteropX NUSPEC
- Add EditorConfig settings for NUSPEC
- Update API usage in FFmpegJcfPlayer

NOTE: the updated NuGet version does not apply the minimalistic build flags.
This will be done on a subsequent version.

## Motivation

Reproducible sources for `Hyvart.FFmpegInteropX` `0.0.3` are no longer available.

That version is also uses a considerably outdated FFmpeg.

It is best to keep a custom NUSPEC to use against the ad-hoc FFmpegInteropX build.